### PR TITLE
fix: dotfiles audit corrections

### DIFF
--- a/fish/config.fish
+++ b/fish/config.fish
@@ -67,6 +67,9 @@ if status is-interactive
 
     # Zoxide
     command -s zoxide > /dev/null; and zoxide init --cmd j --hook pwd fish | source
+
+    # Direnv
+    command -s direnv > /dev/null; and direnv hook fish | source
   end
 end
 
@@ -123,9 +126,9 @@ if set -q KITTY_INSTALLATION_DIR
 end
 
 # Pyenv
-while set pyenv_index (contains -i -- "/Users/sklatt/.pyenv/shims" $PATH)
+while set pyenv_index (contains -i -- "$PYENV_ROOT/shims" $PATH)
 set -eg PATH[$pyenv_index]; end; set -e pyenv_index
-set -gx PATH '/Users/sklatt/.pyenv/shims' $PATH
+set -gx PATH "$PYENV_ROOT/shims" $PATH
 set -gx PYENV_SHELL fish
 
 # Cache pyenv prefix (brew --prefix is slow)
@@ -157,9 +160,9 @@ end
 fish_add_path $HOME/.opencode/bin
 
 # Fish
-# Load key bindings only once at startup
-fish_user_key_bindings
+# Load key bindings only once at startup (vi first, then custom on top)
 fish_vi_key_bindings
+fish_user_key_bindings
 
 # Defer theme application to first prompt if not already set
 if status is-interactive; and not set -q __FISH_THEME_LOADED

--- a/fish/functions/fzf_cd.fish
+++ b/fish/functions/fzf_cd.fish
@@ -4,7 +4,7 @@ function fzf_cd --description "Interactive cd"
         exit 1
     end
 
-    find * -type d | fzf --header="Change directory" --tiebreak=end,length | read -l fzf_last_select
+    fd --type d | fzf --header="Change directory" --tiebreak=end,length | read -l fzf_last_select
     if [ $fzf_last_select ]
         cd $fzf_last_select
     end

--- a/fish/functions/fzf_file_edit.fish
+++ b/fish/functions/fzf_file_edit.fish
@@ -3,7 +3,7 @@ function fzf_file_edit --description 'Select files and open in editor'
         echo 'error: fzf not found'
         exit 1
     end
-    fzf --header="Edit files" --preview="head -$LINES {}" -m -q (commandline -t) | read -z -l fzf_last_select
+    fzf --header="Edit files" --preview="bat --color=always --style=numbers {}" -m -q (commandline -t) | read -z -l fzf_last_select
     if [ $fzf_last_select ]
         string split '\n' $fzf_last_select | string join ' ' | xargs nvim -o
     end

--- a/gitconfig
+++ b/gitconfig
@@ -22,12 +22,19 @@
 
 [rebase]
     autosquash = true
+    updateRefs = true
 
 [pull]
     rebase = true
 
+[fetch]
+    prune = true
+
+[branch]
+    sort = -committerdate
+
 [merge]
-    conflictstyle = diff3
+    conflictstyle = zdiff3
     ff = true
 
 [diff]
@@ -62,7 +69,7 @@
     git = !exec git
     edit = config --global -e
 
-    contributers = authors --list
+    contributors = authors --list
 
     c = commit
     fix = commit --fixup
@@ -109,7 +116,7 @@
     changed-files = log --stat --oneline
     changes = log --pretty=changelog
     overview = log --graph --branches --remotes --tags --pretty=default --date-order
-    unmerged = log --no-merges master..
+    unmerged = log --no-merges main..
     today = log -u --name-only --since='1 day ago' --remotes --branches --date-order --tags --pretty=default
 
     tracked = ls-files
@@ -120,13 +127,13 @@
     mt = mergetool
 
     pl = pull
-    plm = pull origin master
+    plm = pull origin main
     pla = pull --all
     plnr = pull --no-rebase
     pull-merge = pull --no-rebase
 
     p = push
-    pm = push origin master
+    pm = push origin main
 
     rb = rebase
     rbi = rebase --interactive
@@ -146,7 +153,7 @@
     stashes = stash list
 
     t = tag -n
-    last-tag = describe --tags --abrev=0
+    last-tag = describe --tags --abbrev=0
 
     home = "!gh repo view --web"
 

--- a/kitty/kitty.conf
+++ b/kitty/kitty.conf
@@ -6,9 +6,6 @@ include themes/rose-pine-moon.conf
 font_size        16.0
 font_family      JetBrainsMono Nerd Font Mono
 font_features    JetBrainsMono Nerd Font Mono +ss01 +ss02 +ss03 +ss04 +ss05 +ss07 +ss08 +zero +onum
-bold_font        JetBrainsMono Nerd Font Mono Bold
-italic_font      JetBrainsMono Nerd Font Mono Italic
-bold_italic_font JetBrainsMono Nerd Font Mono Bold Italic
 
 text_composition_strategy platform
 

--- a/starship.toml
+++ b/starship.toml
@@ -20,8 +20,6 @@ $character\
 
 right_format = """
 [](bg:base)\
-($kubernetes)\
-($gcloud)\
 ($cmd_duration)\
 ($status)\
 """

--- a/tmux.conf
+++ b/tmux.conf
@@ -52,16 +52,13 @@ set -g history-limit 100000
 # Modes
 set -g status-keys vi
 setw -g mode-keys vi
-setw -g xterm-keys on
 
 # Mouse
 set -g mouse on
 
 # Size
 set -g main-pane-width '60%'
-set -g other-pane-width '40%'
 set -g main-pane-height '60%'
-set -g other-pane-height '40%'
 
 # Bar
 set -g status-position top


### PR DESCRIPTION
Fix hardcoded pyenv shims path ($PYENV_ROOT/shims). Add missing direnv
hook to fish startup. Fix fish_vi_key_bindings order so custom bindings
are not shadowed. Fix last-tag alias (--abbrev typo), contributors typo,
master->main in plm/pm/unmerged aliases. Upgrade merge.conflictstyle to
zdiff3, add fetch.prune, branch.sort, rebase.updateRefs. Remove
deprecated kitty bold/italic font keys, tmux other-pane-* and xterm-keys
options. Remove disabled gcloud/kubernetes from starship right_format.
Replace head/find with bat/fd in fzf functions.
