### PR TITLE
refactor: review and update tmux and kitty configs

### DIFF
--- a/fish/functions/tmux.fish
+++ b/fish/functions/tmux.fish
@@ -9,6 +9,8 @@ function tmux --description 'Attach to tmux session'
                 case 1
                     if [ ! $TMUX ]
                         command tmux new-session -A -s (echo $sessions | cut -f 1 -d " ")
+                    else
+                        command tmux display "Already in session: #S"
                     end
                     return 0
                 case '*'

--- a/kitty/kitty.conf
+++ b/kitty/kitty.conf
@@ -1,5 +1,5 @@
 shell_integration disabled
-shell /opt/homebrew/bin/tmux new-session -A -s "main"
+shell tmux new-session -A -s "main"
 
 include themes/rose-pine-moon.conf
 
@@ -27,13 +27,14 @@ url_prefixed https http git ssh ftp sftp mailto kitty
 repaint_delay 10
 input_delay 1
 sync_to_monitor no
+undercurl_style thick-sparse
 
 scrollback_lines    0
 mouse_hide_wait     2.0
 window_border_width 0
 placement_strategy  top-left
 
-enable_audio_bell yes
+enable_audio_bell no
 
 remember_window_size  yes
 initial_window_width  640
@@ -45,6 +46,6 @@ hide_window_decorations yes
 confirm_os_window_close 0
 close_on_child_death    yes
 
-macos_option_as_alt                false
+macos_option_as_alt                yes
 macos_quit_when_last_window_closed yes
 

--- a/kitty/kitty.conf
+++ b/kitty/kitty.conf
@@ -48,8 +48,3 @@ close_on_child_death    yes
 macos_option_as_alt                false
 macos_quit_when_last_window_closed yes
 
-map alt+k send_key alt+k
-map alt+j send_key alt+j
-map alt+h send_key alt+h
-map alt+l send_key alt+l
-map alt+z send_key alt+z

--- a/tmux.conf
+++ b/tmux.conf
@@ -17,27 +17,28 @@ thm_hl_med="#44415a"
 thm_hl_high="#56526e"
 
 if-shell 'test -n "$KITTY_INSTALLATION_DIR"' 'set -g default-terminal "xterm-kitty"' 'set -g default-terminal "screen-256color"'
-set -g default-command "/opt/homebrew/bin/fish --interactive"
+set -g default-command "fish"
 
 set -g allow-passthrough on
 set -ga update-environment TERM
 set -ga update-environment TERM_PROGRAM
 set -as terminal-overrides ',*:Smulx=\E[4::%p1%dm'
 set -as terminal-overrides ',*:Setulc=\E[58::2::%p1%{65536}%/%d::%p1%{256}%/%{255}%&%d::%p1%{255}%&%d%;m'
+set -g extended-keys on
 
 # Timing optimized for latency
 set -g display-time 1000
 set -g display-panes-time 3000
 set -g status-interval 120
 set -g repeat-time 500
-set -sg escape-time 10
+set -sg escape-time 0
 
 # Indexing
 set -g base-index 1
 set -wg pane-base-index 1
 
 # Behavior
-set -wg monitor-activity off
+set -wg monitor-activity on
 set -g focus-events on
 set -g renumber-windows on
 set -wg automatic-rename on
@@ -139,7 +140,7 @@ bind 8 display-popup -T "K9s" -w "90%" -h "90%" -E "k9s"
 
 # yazi popup
 unbind y
-bind y display-popup -T "Yazi" -w "90%" -h "90%" -E "tmux new-session yazi \; set status off"
+bind y display-popup -T "Yazi" -w "90%" -h "90%" -d "#{pane_current_path}" -E "yazi"
 
 # fish popup
 unbind f
@@ -186,6 +187,8 @@ bind -n M-z resize-pane -Z
 
 
 # Clipboard
+set -g copy-command "pbcopy"
+set -g word-separators " /@:.,;|"
 unbind Escape
 bind Escape copy-mode
 unbind p
@@ -197,7 +200,7 @@ bind -Tcopy-mode-vi v send -X begin-selection
 unbind -Tcopy-mode-vi c-v
 bind -Tcopy-mode-vi C-v send -X rectangle-toggle
 unbind -Tcopy-mode-vi y
-bind -Tcopy-mode-vi y send -X copy-pipe-and-cancel "pbcopy"
+bind -Tcopy-mode-vi y send -X copy-pipe-and-cancel
 
 # Window
 unbind c


### PR DESCRIPTION
## Summary

**tmux.conf**
- Fix hardcoded Homebrew fish path in `default-command` to portable `fish`
- Set `escape-time 0` (safe since tmux 3.2, removes residual Escape delay)
- Add `extended-keys on` for proper kitty modifier key encoding via KKP
- Enable `monitor-activity on` by default so the status bar blink indicator is active
- Add global `copy-command "pbcopy"`; simplify `y` copy-mode binding to use it
- Add `word-separators " /@:.,;|"` for better word navigation in copy mode (paths, URLs)
- Fix yazi popup to run `yazi` directly with `#{pane_current_path}` instead of via a nested tmux session

**kitty/kitty.conf**
- Fix hardcoded Homebrew tmux path in `shell` directive to portable `tmux`
- Remove now-redundant `map alt+hjklz send_key` workarounds (superseded by `extended-keys on` + KKP)
- Set `macos_option_as_alt yes` so Option acts as Alt on macOS, consistent with tmux `M-h/j/k/l/z` bindings
- Disable audio bell
- Add `undercurl_style thick-sparse` for more visible LSP diagnostic squiggles in neovim (tmux `Smulx`/`Setulc` passthrough confirmed correct)

**fish/functions/tmux.fish**
- Show `"Already in session: #S"` when invoking `tmux` while already attached to the only session, instead of silently doing nothing