### PR TITLE
fix: update tmux and yazi configs for breaking changes

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -178,10 +178,10 @@ bind-key -n 'M-k' if-shell "$is_vim" 'send-keys M-k'  'select-pane -U'
 bind-key -n 'M-l' if-shell "$is_vim" 'send-keys M-l'  'select-pane -R'
 
  # Pane resizing
-bind -n M-H resize-pane -L 5
-bind -n M-J resize-pane -D 5
-bind -n M-K resize-pane -U 5
-bind -n M-L resize-pane -R 5
+bind -n M-S-h resize-pane -L 5
+bind -n M-S-j resize-pane -D 5
+bind -n M-S-k resize-pane -U 5
+bind -n M-S-l resize-pane -R 5
 unbind z
 bind -n M-z resize-pane -Z
 

--- a/yazi/theme.toml
+++ b/yazi/theme.toml
@@ -3,10 +3,6 @@
 [mgr]
 cwd = { fg = "#9ccfd8" }
 
-# Hovered
-hovered = { fg = "#e0def4", bg = "#26233a" }
-preview_hovered = { underline = true }
-
 # Find
 find_keyword = { fg = "#f6c177", italic = true }
 find_position = { fg = "#eb6f92", bg = "reset", italic = true }
@@ -27,6 +23,15 @@ border_style = { fg = "#524f67" }
 
 # Highlighting
 syntect_theme = "~/.config/yazi/rose-pine.tmTheme"
+
+# : }}}
+
+
+# : Indicator {{{
+
+[indicator]
+current = { fg = "#e0def4", bg = "#26233a" }
+preview = { underline = true }
 
 # : }}}
 
@@ -136,8 +141,8 @@ rules = [
     { mime = "application/x-rar", fg = "#eb6f92" },
 
     # Fallback
-    { name = "*", fg = "#e0def4" },
-    { name = "*/", fg = "#524f67" },
+    { url = "*", fg = "#e0def4" },
+    { url = "*/", fg = "#524f67" },
 ]
 
 # : }}}

--- a/yazi/yazi.toml
+++ b/yazi/yazi.toml
@@ -48,7 +48,7 @@ play = [
 [open]
 rules = [
 	# Folder
-	{ name = "*/", use = [ "edit", "open", "reveal" ] },
+	{ url = "*/", use = [ "edit", "open", "reveal" ] },
 	# Text
 	{ mime = "text/*", use = [ "edit", "reveal" ] },
 	# Image
@@ -63,7 +63,7 @@ rules = [
 	# Empty file
 	{ mime = "inode/empty", use = [ "edit", "reveal" ] },
 	# Fallback
-	{ name = "*", use = [ "open", "reveal" ] },
+	{ url = "*", use = [ "open", "reveal" ] },
 ]
 
 [tasks]
@@ -77,10 +77,10 @@ suppress_preload = false
 [plugin]
 fetchers = [
 	# Mimetype
-	{ id = "mime", name = "*", run = "mime", prio = "high" },
+	{ id = "mime.local", url = "*", run = "mime", prio = "high" },
 ]
 spotters = [
-	{ name = "*/", run = "folder" },
+	{ url = "*/", run = "folder" },
 	# Code
 	{ mime = "text/*", run = "code" },
 	{ mime = "application/{mbox,javascript,wine-extension-ini}", run = "code" },
@@ -91,7 +91,7 @@ spotters = [
 	# Video
 	{ mime = "video/*", run = "video" },
 	# Fallback
-	{ name = "*", run = "file" },
+	{ url = "*", run = "file" },
 ]
 preloaders = [
 	# Image
@@ -107,7 +107,7 @@ preloaders = [
 	{ mime = "application/ms-opentype", run = "font" },
 ]
 previewers = [
-	{ name = "*/", run = "folder" },
+	{ url = "*/", run = "folder" },
 	# Code
 	{ mime = "text/*", run = "code" },
 	{ mime = "application/{mbox,javascript,wine-extension-ini}", run = "code" },
@@ -124,18 +124,18 @@ previewers = [
 	# Archive
 	{ mime = "application/{zip,rar,7z*,tar,gzip,xz,zstd,bzip*,lzma,compress,archive,cpio,arj,xar,ms-cab*}", run = "archive" },
 	{ mime = "application/{debian*-package,redhat-package-manager,rpm,android.package-archive}", run = "archive" },
-	{ name = "*.{AppImage,appimage}", run = "archive" },
+	{ url = "*.{AppImage,appimage}", run = "archive" },
 	# Virtual Disk / Disk Image
 	{ mime = "application/{iso9660-image,qemu-disk,ms-wim,apple-diskimage}", run = "archive" },
 	{ mime = "application/virtualbox-{vhd,vhdx}", run = "archive" },
-	{ name = "*.{img,fat,ext,ext2,ext3,ext4,squashfs,ntfs,hfs,hfsx}", run = "archive" },
+	{ url = "*.{img,fat,ext,ext2,ext3,ext4,squashfs,ntfs,hfs,hfsx}", run = "archive" },
 	# Font
 	{ mime = "font/*", run = "font" },
 	{ mime = "application/ms-opentype", run = "font" },
 	# Empty file
 	{ mime = "inode/empty", run = "empty" },
 	# Fallback
-	{ name = "*", run = "file" },
+	{ url = "*", run = "file" },
 ]
 
 [input]


### PR DESCRIPTION
## What was checked

Ran weekly breaking-change audit against latest stable releases (as of 2026-03-28):

| Tool | Latest stable | Breaking changes found? |
|---|---|---|
| tmux | 3.6a | **Yes** — M-uppercase key binding behavior |
| yazi | v26.1.22 (config break in v25.12.29) | **Yes** — VFS release renamed config keys |
| fish | 4.6.0 | No (deprecation only, still works) |
| neovim | 0.11.6 | No (config already uses new patterns) |
| kitty | 0.46.2 | No (no `background_opacity`+`background_image` combo) |
| starship | 1.24.2 | No |
| lazygit | 0.60.0 | No (no removed keys in this config) |

## Changes

### `tmux.conf` — tmux 3.6

In tmux 3.6, `M-` followed by an uppercase letter (e.g. `M-H`) no longer implicitly means Meta+Shift+letter. The explicit form `M-S-h` is now required.

The four pane-resize bindings were affected:
- `bind -n M-H` → `bind -n M-S-h`
- `bind -n M-J` → `bind -n M-S-j`
- `bind -n M-K` → `bind -n M-S-k`
- `bind -n M-L` → `bind -n M-S-l`

Without this fix, Alt+Shift+hjkl pane resizing silently stops working after upgrading to tmux 3.6.

### `yazi/yazi.toml` + `yazi/theme.toml` — yazi v25.12.29 (VFS release)

This release introduced Virtual File System support and renamed several config keys:

1. **`name` → `url`** in `[open].rules`, `[plugin].spotters`, `[plugin].previewers`, and `[filetype].rules`. The old `name` key is no longer recognized.

2. **Fetcher id `"mime"` → `"mime.local"`** in `[plugin].fetchers`. The built-in MIME fetcher was split into `mime.local` (files) and `mime.dir` (directories).

3. **`[mgr].hovered` / `[mgr].preview_hovered` moved to new `[indicator]` section** as `current` / `preview`. Without this fix, the highlighted file row and preview pane hover style are lost entirely.

## Verification before merging

- [ ] Restart tmux server (`tmux kill-server`) and verify Alt+Shift+hjkl resizes panes
- [ ] Launch yazi and confirm hovered file highlighting and preview hover underline still render correctly
- [ ] Open a folder in yazi to confirm the folder previewer loads (tests the `url` key change)