### PR TITLE
install: replace deprecated/superseded CLI tools with modern alternatives

### DIFF
--- a/install/devops.sh
+++ b/install/devops.sh
@@ -26,7 +26,7 @@ FORMULAS=(
     terraform-docs
     terragrunt
     tflint
-    tfsec
+    trivy # IaC + container + secrets scanner (replaces tfsec; tfsec merged into trivy)
 )
 
 CASKS=(

--- a/install/go.sh
+++ b/install/go.sh
@@ -5,21 +5,16 @@ PATH=/usr/local/bin:$PATH
 source "${BASH_SOURCE%/*}/lib.sh"
 
 TOOLS=(
-    github.com/lukehoban/go-outline@latest
-    github.com/mailgun/godebug@latest
     github.com/x-motemen/gore/cmd/gore@latest
-    github.com/newhook/go-symbols@latest
-    github.com/nsf/gocode@latest
-    github.com/rogpeppe/godef@latest
-    github.com/tools/godep@latest
-    github.com/tpng/gopkgs@latest
-    golang.org/x/lint/golint@latest
     golang.org/x/tools/gopls@latest
-    sourcegraph.com/sqs/goreturns@latest
+    github.com/go-delve/delve/cmd/dlv@latest    # debugger (replaces godebug)
+    golang.org/x/tools/cmd/goimports@latest     # auto-manage imports (replaces goreturns)
+    mvdan.cc/gofumpt@latest                     # stricter gofmt
 )
 
 FORMULAS=(
     go
+    golangci-lint # meta-linter (replaces golint)
 )
 
 h1 "go"

--- a/install/minimal.sh
+++ b/install/minimal.sh
@@ -33,8 +33,8 @@ FORMULAS=(
     gnu-tar
     gnupg
     grep
+    bandwhich # network utilization by process/connection (replaces iftop)
     grpcurl
-    iftop
     jq
     lazygit
     less
@@ -57,8 +57,8 @@ FORMULAS=(
     tmux
     tree
     watch
+    oha  # rust-based HTTP benchmarker with TUI histogram (replaces wrk)
     wget
-    wrk
     xo/xo/usql
     xz
     yazi

--- a/install/util.sh
+++ b/install/util.sh
@@ -10,26 +10,22 @@ TAPS=(
     homebrew/core
 )
 
-EGGS=(
-    http-prompt
-)
-
 FORMULAS=(
-    bat # cat replacment with line numbers and syntax highlighting
+    bat # cat replacement with line numbers and syntax highlighting
     calc
-    ccat # cat replacement with syntax highlighting
     cloc
     cloog
     entr
     fdupes
     fx # json terminal viewer
+    glow # markdown renderer with pager support (replaces mdcat)
     go-task
     graphviz
+    hurl # scriptable HTTP request runner (.hurl files)
     jo
     lua
     luajit
     mandoc
-    mdcat
     pv
     ragel
     rclone
@@ -39,6 +35,7 @@ FORMULAS=(
     upx
     vmtouch
     w3m
+    xh   # rust-based httpie-compatible HTTP client (replaces http-prompt)
     yank
 )
 
@@ -57,5 +54,3 @@ h2 "brew casks"
 for f in "${CASKS[@]}"; do cask_install "$f"; done
 h2 "brew formulas"
 for f in "${FORMULAS[@]}"; do brew_install "$f"; done
-h2 "pip modules"
-for e in "${EGGS[@]}"; do pip_install "$e"; done


### PR DESCRIPTION
go.sh: remove 9 archived/deprecated tools (gocode, godep, golint, godebug,
godef, go-outline, go-symbols, gopkgs, goreturns — all superseded by gopls
or Go modules); add dlv (debugger), goimports, gofumpt, golangci-lint

util.sh: drop ccat (redundant with bat) and http-prompt (Python); add xh
(Rust httpie clone), hurl (scriptable HTTP test runner), glow (markdown
renderer); replace mdcat with glow; remove pip section

minimal.sh: replace iftop with bandwhich (Rust, per-process bandwidth);
replace wrk with oha (Rust benchmarker with TUI histogram output)

devops.sh: replace tfsec with trivy (tfsec was merged into trivy by Aqua
Security; trivy covers IaC, containers, secrets, SBOMs)

https://claude.ai/code/session_011Qnvmb5wxPmfE8U31uyku2