### PR TITLE
fix: address nvim config review findings

### DIFF
--- a/nvim/lua/config/keymaps.lua
+++ b/nvim/lua/config/keymaps.lua
@@ -1,38 +1,38 @@
 -- Process & io
-vim.api.nvim_set_keymap('n', 'q', ':quitall<cr>', { desc = 'Exit current window', silent = true })
-vim.api.nvim_set_keymap('n', '<leader>q', ':quitall<cr>', { desc = 'Exit neovim', silent = true })
-vim.api.nvim_set_keymap('n', '<leader><s-q>', ':quitall!<cr>', { desc = 'Exit neovim without saving', silent = true })
-vim.api.nvim_set_keymap('n', '<leader>w', ':write<cr>', { desc = 'Write current buffer', silent = true })
-vim.api.nvim_set_keymap('n', '<leader>c', ':close<cr>', { desc = 'Close panel', silent = true })
-vim.api.nvim_set_keymap('n', '<leader>d', ':bd<cr>', { desc = 'Delete current buffer', silent = true })
+vim.keymap.set('n', 'q', ':quit<cr>', { desc = 'Exit current window', silent = true })
+vim.keymap.set('n', '<leader>q', ':quitall<cr>', { desc = 'Exit neovim', silent = true })
+vim.keymap.set('n', '<leader><s-q>', ':quitall!<cr>', { desc = 'Exit neovim without saving', silent = true })
+vim.keymap.set('n', '<leader>w', ':write<cr>', { desc = 'Write current buffer', silent = true })
+vim.keymap.set('n', '<leader>c', ':close<cr>', { desc = 'Close panel', silent = true })
+vim.keymap.set('n', '<leader>d', ':bd<cr>', { desc = 'Delete current buffer', silent = true })
 
 -- Move to next/prev buffer
-vim.api.nvim_set_keymap('n', '<tab>', ':bnext<cr>', { noremap = true, silent = true })
-vim.api.nvim_set_keymap('n', '<s-tab>', ':bprev<cr>', { noremap = true, silent = true })
+vim.keymap.set('n', '<tab>', ':bnext<cr>', { silent = true })
+vim.keymap.set('n', '<s-tab>', ':bprev<cr>', { silent = true })
 
 -- Set and remove search highlight
-vim.api.nvim_set_keymap('n', '<leader><esc>', ':setlocal nohlsearch<cr>', { desc = 'Remove highlighting', silent = true })
-vim.api.nvim_set_keymap('n', '/', ':setlocal hlsearch<cr>/', { noremap = true })
+vim.keymap.set('n', '<leader><esc>', ':setlocal nohlsearch<cr>', { desc = 'Remove highlighting', silent = true })
+vim.keymap.set('n', '/', ':setlocal hlsearch<cr>/', { noremap = true })
 
 -- Yank until end of line
-vim.api.nvim_set_keymap('n', 'Y', 'y$', { noremap = true })
+vim.keymap.set('n', 'Y', 'y$')
 
 -- Jump over wrapped lines
-vim.api.nvim_set_keymap('n', 'j', 'gj', { noremap = true })
-vim.api.nvim_set_keymap('n', 'k', 'gk', { noremap = true })
-vim.api.nvim_set_keymap('n', 'gj', 'j', { noremap = true })
-vim.api.nvim_set_keymap('n', 'gk', 'k', { noremap = true })
+vim.keymap.set('n', 'j', 'gj')
+vim.keymap.set('n', 'k', 'gk')
+vim.keymap.set('n', 'gj', 'j')
+vim.keymap.set('n', 'gk', 'k')
 
 -- Indenting
-vim.api.nvim_set_keymap('n', '<', '<<', { noremap = true })
-vim.api.nvim_set_keymap('n', '>', '>>', { noremap = true })
-vim.api.nvim_set_keymap('v', '<', '<gv', { noremap = true })
-vim.api.nvim_set_keymap('v', '>', '>gv', { noremap = true })
+vim.keymap.set('n', '<', '<<')
+vim.keymap.set('n', '>', '>>')
+vim.keymap.set('v', '<', '<gv')
+vim.keymap.set('v', '>', '>gv')
 
 -- Walk history with j/k
-vim.api.nvim_set_keymap('c', '<c-j>', '<down>', { noremap = true })
-vim.api.nvim_set_keymap('c', '<c-k>', '<up>', { noremap = true })
+vim.keymap.set('c', '<c-j>', '<down>')
+vim.keymap.set('c', '<c-k>', '<up>')
 
 -- Do not yank while visual paste
-vim.api.nvim_set_keymap('v', 'p', '"_dp', { noremap = true })
-vim.api.nvim_set_keymap('v', 'P', '"_dP', { noremap = true })
+vim.keymap.set('v', 'p', '"_dp')
+vim.keymap.set('v', 'P', '"_dP')

--- a/nvim/lua/config/options.lua
+++ b/nvim/lua/config/options.lua
@@ -69,7 +69,7 @@ vim.o.autoindent = true -- auto indent next line
 vim.o.copyindent = true -- use the same indentation for autoindent
 vim.o.smartindent = true -- do smart autoindenting when starting a new line
 vim.o.startofline = false -- cursor stays at same column while moving horizontal
-vim.o.joinspaces = true -- do not add additional spaces on join
+vim.o.joinspaces = true -- add extra space after '.', '?' and '!' on join
 vim.o.clipboard = 'unnamed'
 vim.o.formatoptions = 'qcnrj'
 --                     |||||

--- a/nvim/lua/plugins/completion.lua
+++ b/nvim/lua/plugins/completion.lua
@@ -1,0 +1,30 @@
+return {
+  'saghen/blink.cmp',
+  version = '*',
+  event = 'InsertEnter',
+  opts = {
+    keymap = {
+      preset = 'default',
+      ['<CR>'] = { 'accept', 'fallback' },
+      ['<C-n>'] = { 'select_next', 'fallback' },
+      ['<C-p>'] = { 'select_prev', 'fallback' },
+      ['<C-e>'] = { 'hide', 'fallback' },
+    },
+    appearance = {
+      nerd_font_variant = 'mono',
+    },
+    sources = {
+      default = { 'lsp', 'path', 'snippets', 'buffer' },
+    },
+    completion = {
+      documentation = {
+        auto_show = true,
+        window = { border = 'rounded' },
+      },
+      menu = {
+        border = 'rounded',
+      },
+      ghost_text = { enabled = true },
+    },
+  },
+}

--- a/nvim/lua/plugins/dap.lua
+++ b/nvim/lua/plugins/dap.lua
@@ -15,17 +15,17 @@ return {
       desc = 'Debug: Start/Continue',
     },
     {
-      '<leader>dsi',
+      '<leader>di',
       function() require('dap').step_into() end,
       desc = 'Debug: Step Into',
     },
     {
-      '<leader>dsO',
+      '<leader>dv',
       function() require('dap').step_over() end,
       desc = 'Debug: Step Over',
     },
     {
-      '<leader>dso',
+      '<leader>do',
       function() require('dap').step_out() end,
       desc = 'Debug: Step Out',
     },

--- a/nvim/lua/plugins/git.lua
+++ b/nvim/lua/plugins/git.lua
@@ -2,7 +2,7 @@ return {
   {
     'lewis6991/gitsigns.nvim',
     event = { 'BufReadPre', 'BufNewFile' },
-    keys = { { 'gn', ':Gitsigns next_hunk<CR>', noremap = true }, { 'gp', ':Gitsigns prev_hunk<CR>', noremap = true } },
+    keys = { { ']h', ':Gitsigns next_hunk<CR>', noremap = true }, { '[h', ':Gitsigns prev_hunk<CR>', noremap = true } },
     config = function()
       local gitsigns = require('gitsigns')
       gitsigns.setup({
@@ -31,7 +31,6 @@ return {
     event = 'BufReadPre',
     config = function()
       vim.g.committia_open_only_vim_starting = 0
-      vim.g.committia_hooks = vim.empty_dict()
     end,
   },
 }

--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -26,7 +26,6 @@ return {
           ':MasonInstall json-lsp',
           ':MasonInstall lua-language-server',
           ':MasonInstall markdownlint',
-          ':MasonInstall python-lsp-server',
           ':MasonInstall ruff',
           ':MasonInstall rust-analyzer',
           ':MasonInstall shellcheck',
@@ -35,6 +34,7 @@ return {
           ':MasonInstall terraform-ls',
           ':MasonInstall tflint',
           ':MasonInstall tfsec',
+          ':MasonInstall yamlfmt',
           ':MasonInstall yamllint',
         },
         opts = {},
@@ -45,7 +45,40 @@ return {
     keys = { { '<leader>cm', '<cmd>Mason<cr>', desc = 'Mason' } },
     config = function()
       require('mason').setup()
-      require('mason-lspconfig').setup()
+
+      local on_attach = function(_, bufnr)
+        local map = function(keys, func, desc)
+          vim.keymap.set('n', keys, func, { buffer = bufnr, desc = desc })
+        end
+        map('gd', vim.lsp.buf.definition, 'Goto Definition')
+        map('gD', vim.lsp.buf.declaration, 'Goto Declaration')
+        map('gi', vim.lsp.buf.implementation, 'Goto Implementation')
+        map('gr', vim.lsp.buf.references, 'Goto References')
+        map('K', vim.lsp.buf.hover, 'Hover Documentation')
+        map('<leader>lr', vim.lsp.buf.rename, 'Rename')
+        map('<leader>la', vim.lsp.buf.code_action, 'Code Action')
+        map('[d', vim.diagnostic.goto_prev, 'Previous Diagnostic')
+        map(']d', vim.diagnostic.goto_next, 'Next Diagnostic')
+        map('<leader>lf', vim.diagnostic.open_float, 'Show Diagnostic Float')
+      end
+
+      local capabilities = vim.lsp.protocol.make_client_capabilities()
+      local ok, blink = pcall(require, 'blink.cmp')
+      if ok then
+        capabilities = blink.get_lsp_capabilities(capabilities)
+      end
+
+      require('mason-lspconfig').setup({
+        handlers = {
+          function(server_name)
+            local server_ok, server_config = pcall(require, 'lsp.' .. server_name)
+            local config = server_ok and server_config or {}
+            config.on_attach = on_attach
+            config.capabilities = capabilities
+            require('lspconfig')[server_name].setup(config)
+          end,
+        },
+      })
 
       vim.diagnostic.config({
         virtual_text = true,


### PR DESCRIPTION
- lsp: add on_attach with LSP keybindings (gd, gD, gi, gr, K, <leader>l*),
  wire up mason-lspconfig handlers to load server configs from lsp/ dir,
  add blink.cmp capability integration, remove python-lsp-server (conflicts
  with basedpyright), add yamlfmt to Mason install list
- completion: add blink.cmp with LSP/path/snippets/buffer sources,
  ghost text, rounded borders, CR to accept
- keymaps: change q → :quit (was :quitall, too aggressive), migrate
  all vim.api.nvim_set_keymap calls to vim.keymap.set
- git: change gn/gp hunk navigation to ]h/[h (gn is a built-in vim motion),
  remove no-op committia_hooks empty dict
- dap: rename dsi/dsO/dso step bindings to di/dv/do (clearer, no case ambiguity)
- options: fix joinspaces comment (was saying the opposite of what true does)

https://claude.ai/code/session_01SHQvTd2bPdYx8xHAs9MJPF