### PR TITLE
overhaul lazygit config with full rose-pine-moon theme and power-user features

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -179,7 +179,7 @@
     root = ~/Developer/repos
 
 [delta]
-    features = arctic-fox
+    features = rose-pine-moon
 
 [delta "arctic-fox"]
     # author: https://github.com/anthony-halim
@@ -220,8 +220,10 @@
 [delta "rose-pine-moon"]
     dark = true
     syntax-theme = Nord
+    navigate = true
+    hyperlinks = true
 
-    thm-nc = "#1f1d30"
+    # palette
     thm-base = "#232136"
     thm-surface = "#2a273f"
     thm-overlay = "#393552"
@@ -238,7 +240,9 @@
     thm-hl-med = "#44415a"
     thm-hl-high = "#56526e"
 
+    blame-code-style = syntax
     blame-format = "{author:<18} ({commit:>7}) ┊{timestamp:^16}┊ "
+    blame-palette = "#232136" "#2a273f" "#393552"
     commit-decoration-style = "#f6c177" box
     commit-style = "#f6c177" bold italic
     file-added-label = [+]
@@ -256,20 +260,20 @@
     line-numbers-left-format = "{nm:>3} │"
     line-numbers-left-style = "#6e6a86"
     line-numbers-minus-style = "#eb6f92" bold
-    line-numbers-plus-style = "#3e8fb0" bold
+    line-numbers-plus-style = "#9ccfd8" bold
     line-numbers-right-format = "{np:>3} │"
     line-numbers-right-style = "#6e6a86"
     line-numbers-zero-style = "#908caa" italic
-    merge-conflict-begin-symbol = ~
-    merge-conflict-end-symbol = ~
+    merge-conflict-begin-symbol = ╔
+    merge-conflict-end-symbol = ╚
     merge-conflict-ours-diff-header-decoration-style = "#56526e" box
     merge-conflict-ours-diff-header-style = "#f6c177" bold
     merge-conflict-theirs-diff-header-decoration-style = "#56526e" box
-    merge-conflict-theirs-diff-header-style = "#f6c177" bold
-    minus-emph-style = bold "#eb6f92" "#393552"
+    merge-conflict-theirs-diff-header-style = "#ea9a97" bold
+    minus-emph-style = bold "#eb6f92" "#44415a"
     minus-style = "#eb6f92"
-    plus-emph-style = bold "#3e8fb0" "#393552"
-    plus-style = "#3e8fb0"
+    plus-emph-style = bold "#9ccfd8" "#44415a"
+    plus-style = "#9ccfd8"
     whitespace-error-style = "#eb6f92" reverse
     zero-style = "#e0def4"
 

--- a/lazygit/config.yml
+++ b/lazygit/config.yml
@@ -1,5 +1,5 @@
 gui:
-  scrollHeight: 2
+  scrollHeight: 3
   scrollPastBottom: true
   scrollOffMargin: 5
   scrollOffBehavior: margin
@@ -8,51 +8,42 @@ gui:
   skipStashWarning: false
   skipNoStagedFilesWarning: false
   skipRewordInEditorWarning: false
-  sidePanelWidth: 0.3
+  sidePanelWidth: 0.28
   expandFocusedSidePanel: true
-  expandedSidePanelWeight: 2
+  expandedSidePanelWeight: 3
   mainPanelSplitMode: flexible
   enlargedSideViewLocation: left
   language: 'en'
-  timeFormat: "02.01.06"
+  timeFormat: "02 Jan 06"
   shortTimeFormat: "15:04"
   theme:
     # rose-pine-moon
     activeBorderColor:
       - '#9ccfd8' # foam
+      - bold
     inactiveBorderColor:
       - '#6e6a86' # muted
     searchingActiveBorderColor:
-      - cyan
+      - '#c4a7e7' # iris
       - bold
-    # Color of keybindings help text in the bottom line
     optionsTextColor:
-      - blue
-    # Background color of selected line.
-    # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#highlighting-the-selected-line
+      - '#9ccfd8' # foam
     selectedLineBgColor:
       - '#393552' # overlay
-    # Background color of selected line when view doesn't have focus.
     inactiveViewSelectedLineBgColor:
-      - bold
-    # Foreground color of copied commit
+      - '#2a283e' # hl-low
     cherryPickedCommitFgColor:
-      - blue
-    # Background color of copied commit
+      - '#c4a7e7' # iris
     cherryPickedCommitBgColor:
-      - cyan
-    # Foreground color of marked base commit (for rebase)
+      - '#393552' # overlay
     markedBaseCommitFgColor:
-      - blue
-    # Background color of marked base commit (for rebase)
+      - '#f6c177' # gold
     markedBaseCommitBgColor:
-      - yellow
-    # Color for file with unstaged changes
+      - '#393552' # overlay
     unstagedChangesColor:
-      - red
-    # Default text color
+      - '#eb6f92' # love
     defaultFgColor:
-      - '#e0def4'
+      - '#e0def4' # text
   commitLength:
     show: true
   showListFooter: true
@@ -61,14 +52,14 @@ gui:
   showCommandLog: false
   showBottomLine: true
   showPanelJumps: true
-  showIcons: false
+  showIcons: true
   nerdFontsVersion: "3"
   showFileIcons: true
   commitAuthorShortLength: 2
   commitAuthorLongLength: 17
   commitHashLength: 8
   showBranchCommitHash: false
-  showDivergenceFromBaseBranch: 'arrowAndNumber'
+  showDivergenceFromBaseBranch: arrowAndNumber
   splitDiff: auto
   screenMode: normal
   border: rounded
@@ -77,33 +68,25 @@ gui:
   filterMode: fuzzy
   spinner:
     frames:
-      - "⠋"
-      - "⠙"
-      - "⠚"
-      - "⠒"
-      - "⠂"
-      - "⠂"
-      - "⠒"
-      - "⠲"
-      - "⠴"
-      - "⠦"
-      - "⠖"
-      - "⠒"
-      - "⠐"
-      - "⠐"
-      - "⠒"
-      - "⠓"
-      - "⠋"
-    rate: 50
+      - "⣾"
+      - "⣽"
+      - "⣻"
+      - "⢿"
+      - "⡿"
+      - "⣟"
+      - "⣯"
+      - "⣷"
+    rate: 80
   statusPanelView: dashboard
   switchToFilesAfterStashPop: true
   switchToFilesAfterStashApply: true
+
 git:
-  pagers:
-    - colorArg: always
-      pager: "delta --dark --paging=never"
-      useConfig: false
-      externalDiffCommand: ""
+  paging:
+    colorArg: always
+    pager: "delta --features=rose-pine-moon --paging=never"
+    useConfig: false
+    externalDiffCommand: ""
   commit:
     signOff: false
     autoWrapCommitMessage: true
@@ -111,7 +94,7 @@ git:
   merging:
     manualCommit: false
     args: ""
-    squashMergeMessage: Squash merge {{selectedRef}} into {{currentBranch}}
+    squashMergeMessage: "Squash merge {{selectedRef}} into {{currentBranch}}"
   mainBranches:
     - master
     - main
@@ -120,70 +103,66 @@ git:
   autoRefresh: true
   fetchAll: true
   autoStageResolvedConflicts: true
-  branchLogCmd: git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=medium {{branchName}} --
+  branchLogCmd: "git log --graph --color=always --abbrev-commit --decorate --date=relative --pretty=format:'%C(#9ccfd8)%h%Creset %C(#6e6a86)%ar%Creset  %C(#e0def4)%s%Creset%C(#eb6f92)%d%Creset' {{branchName}} --"
   overrideGpg: false
-  disableForcePushing: true
-  commitPrefix:
-    - pattern: ""
-      replace: ""
+  disableForcePushing: false
   branchPrefix: ""
-  parseEmoji: false
+  parseEmoji: true
   log:
     order: topo-order
     showGraph: always
     showWholeGraph: false
   truncateCopiedCommitHashesTo: 8
   allBranchesLogCmds:
-    - git log --graph --all --color=always --abbrev-commit --decorate --date=relative  --pretty=medium
+    - "git log --graph --all --color=always --abbrev-commit --decorate --date=relative --pretty=format:'%C(#9ccfd8)%h%Creset %C(#6e6a86)%ar%Creset  %C(#e0def4)%s%Creset%C(#eb6f92)%d%Creset'"
+
 update:
   method: never
+
 refresher:
   refreshInterval: 10
   fetchInterval: 60
+
 confirmOnQuit: false
 quitOnTopLevelReturn: false
+
 os:
-  # Command for editing a file. Should contain "{{filename}}".
-  edit: ""
-  # Command for editing a file at a given line number. Should contain
-  # "{{filename}}", and may optionally contain "{{line}}".
-  editAtLine: ""
-  # Same as EditAtLine, except that the command needs to wait until the
-  # window is closed.
-  editAtLineAndWait: ""
-  # For opening a directory in an editor
-  openDirInEditor: ""
-  # A built-in preset that sets all of the above settings. Supported presets
-  # are defined in the getPreset function in editor_presets.go.
-  editPreset: ""
-  # Command for opening a file, as if the file is double-clicked. Should
-  # contain "{{filename}}", but doesn't support "{{line}}".
-  open: ""
-  # Command for opening a link. Should contain "{{link}}".
-  openLink: ""
-  # EditCommand is the command for editing a file.
-  # Deprecated: use Edit instead. Note that semantics are different:
-  # EditCommand is just the command itself, whereas Edit contains a
-  # "{{filename}}" variable.
-  editCommand: ""
-  # EditCommandTemplate is the command template for editing a file
-  # Deprecated: use EditAtLine instead.
-  editCommandTemplate: ""
-  # OpenCommand is the command for opening a file
-  # Deprecated: use Open instead.
-  openCommand: ""
-  # OpenLinkCommand is the command for opening a link
-  # Deprecated: use OpenLink instead.
-  openLinkCommand: ""
-  # CopyToClipboardCmd is the command for copying to clipboard.
-  # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-and-pasting-from-clipboard
-  copyToClipboardCmd: ""
-  # ReadFromClipboardCmd is the command for reading the clipboard.
-  # See https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md#custom-command-for-copying-to-and-pasting-from-clipboard
-  readFromClipboardCmd: ""
+  editPreset: nvim
+
 disableStartupPopups: true
 notARepository: prompt
 promptToReturnFromSubprocess: true
+
+customCommands:
+  # Create a fixup commit targeting the selected commit
+  - key: "<c-f>"
+    context: commits
+    description: "Create fixup commit for selected commit"
+    command: "git commit --fixup={{.SelectedLocalCommit.Sha}}"
+    loadingText: "Creating fixup commit..."
+
+  # Autosquash all fixup commits from selected base
+  - key: "<a-s>"
+    context: commits
+    description: "Autosquash fixup commits from selected base"
+    command: "git rebase --interactive --autosquash {{.SelectedLocalCommit.Sha}}^"
+    subprocess: true
+    loadingText: "Autosquashing..."
+
+  # Delete all local branches already merged into main
+  - key: "D"
+    context: localBranches
+    description: "Delete all merged local branches"
+    command: "git branch --merged main | grep -vE '^\*|^  (main|master)$' | xargs -r git branch -d"
+    loadingText: "Removing merged branches..."
+
+  # Safer force push — will fail if remote has diverged unexpectedly
+  - key: "<a-f>"
+    context: localBranches
+    description: "Force push with --force-with-lease"
+    command: "git push --force-with-lease origin {{.SelectedLocalBranch.Name}}"
+    loadingText: "Force pushing with lease..."
+
 keybinding:
   universal:
     quit: q
@@ -237,9 +216,7 @@ keybinding:
     scrollDownMain-alt2: <c-d>
     executeShellCommand: ':'
     createRebaseOptionsMenu: m
-    # 'Files' appended for legacy reasons
     pushFiles: P
-    # 'Files' appended for legacy reasons
     pullFiles: p
     refresh: R
     createPatchOptionsMenu: <c-p>


### PR DESCRIPTION
- Replace all generic colors (cyan/blue/red/yellow) with rose-pine-moon hex values
- Fix git.pagers typo → git.paging (lazygit config key was wrong)
- Switch delta pager to --features=rose-pine-moon for visual consistency
- Enable showIcons, parseEmoji; fix inactiveViewSelectedLineBgColor to hl-low
- Add bold to activeBorderColor for clearer focus indication
- Use smoother braille spinner at 80ms; improve time/date format
- expandedSidePanelWeight: 3 for more diff space
- Clean os: section down to editPreset: nvim, remove all deprecated fields
- Set disableForcePushing: false (was overly restrictive for power users)
- Add rose-pine-colored branchLogCmd and allBranchesLogCmds pretty formats
- Add 4 custom commands: fixup-commit (<c-f>), autosquash (<a-s>),
  delete-merged-branches (D), force-push-with-lease (<a-f>)
- gitconfig: switch [delta] features from arctic-fox → rose-pine-moon
- Enhance [delta "rose-pine-moon"]: navigate, hyperlinks, blame-palette,
  better merge conflict symbols, foam (not pine) for additions

https://claude.ai/code/session_01SXyiBZsMUTwQZvzpLPSs91