### PR TITLE
feat(yazi): improve config with proper Rose Pine Moon theme and quality-of-life defaults

### DIFF
--- a/yazi/keymap.toml
+++ b/yazi/keymap.toml
@@ -127,6 +127,13 @@ keymap = [
 	{ on = [ "g", "h" ],       run = "cd ~",             desc = "Go home" },
 	{ on = [ "g", "c" ],       run = "cd ~/.config",     desc = "Go ~/.config" },
 	{ on = [ "g", "d" ],       run = "cd ~/Downloads",   desc = "Go ~/Downloads" },
+	{ on = [ "g", "D" ],       run = "cd ~/Desktop",     desc = "Go ~/Desktop" },
+	{ on = [ "g", "o" ],       run = "cd ~/Documents",   desc = "Go ~/Documents" },
+	{ on = [ "g", "p" ],       run = "cd ~/Pictures",    desc = "Go ~/Pictures" },
+	{ on = [ "g", "m" ],       run = "cd ~/Music",       desc = "Go ~/Music" },
+	{ on = [ "g", "v" ],       run = "cd ~/Videos",      desc = "Go ~/Videos" },
+	{ on = [ "g", "t" ],       run = "cd /tmp",          desc = "Go /tmp" },
+	{ on = [ "g", "e" ],       run = "cd /etc",          desc = "Go /etc" },
 	{ on = [ "g", "<Space>" ], run = "cd --interactive", desc = "Jump interactively" },
 	{ on = [ "g", "f" ],       run = "follow",           desc = "Follow hovered symlink" },
 

--- a/yazi/theme.toml
+++ b/yazi/theme.toml
@@ -1,27 +1,37 @@
+# Rose Pine Moon - consistent with nvim, tmux, starship, kitty, lazygit
+#
+# Palette reference:
+#   base    = #232136   surface  = #2a273f   overlay  = #393552
+#   muted   = #6e6a86   subtle   = #908caa   text     = #e0def4
+#   love    = #eb6f92   gold     = #f6c177   rose     = #ea9a97
+#   pine    = #3e8fb0   foam     = #9ccfd8   iris     = #c4a7e7
+#   hl_low  = #2a283e   hl_med   = #44415a   hl_high  = #56526e
+
+
 # : Manager {{{
 
 [mgr]
-cwd = { fg = "#9ccfd8" }
+cwd = { fg = "#c4a7e7" }  # iris — matches starship directory segment
 
 # Find
-find_keyword = { fg = "#f6c177", italic = true }
+find_keyword  = { fg = "#f6c177", bold = true, italic = true }
 find_position = { fg = "#eb6f92", bg = "reset", italic = true }
 
 # Marker
 marker_selected = { fg = "#9ccfd8", bg = "#9ccfd8" }
-marker_copied = { fg = "#f6c177", bg = "#f6c177" }
-marker_cut = { fg = "#B4637A", bg = "#B4637A" }
+marker_copied   = { fg = "#f6c177", bg = "#f6c177" }
+marker_cut      = { fg = "#eb6f92", bg = "#eb6f92" }
 
-# Tab
-tab_active = { fg = "#e0def4", bg = "#191724" }
-tab_inactive = { fg = "#e0def4", bg = "#2A273F" }
-tab_width = 1
+# Tab — active is brighter/more prominent
+tab_active   = { fg = "#e0def4", bg = "#393552", bold = true }
+tab_inactive = { fg = "#908caa", bg = "#2a273f" }
+tab_width    = 1
 
 # Border
 border_symbol = "│"
-border_style = { fg = "#524f67" }
+border_style  = { fg = "#393552" }
 
-# Highlighting
+# Syntax highlighting
 syntect_theme = "~/.config/yazi/rose-pine.tmTheme"
 
 # : }}}
@@ -30,7 +40,7 @@ syntect_theme = "~/.config/yazi/rose-pine.tmTheme"
 # : Indicator {{{
 
 [indicator]
-current = { fg = "#e0def4", bg = "#26233a" }
+current = { fg = "#e0def4", bg = "#2a283e" }
 preview = { underline = true }
 
 # : }}}
@@ -39,26 +49,26 @@ preview = { underline = true }
 # : Status {{{
 
 [status]
-separator_open = ""
-separator_close = ""
-separator_style = { fg = "#2A273F", bg = "#2A273F" }
+separator_open  = ""
+separator_close = ""
+separator_style = { fg = "#2a273f", bg = "#2a273f" }
 
-# Mode
-mode_normal = { fg = "#191724", bg = "#ebbcba", bold = true }
-mode_select = { fg = "#e0def4", bg = "#9ccfd8", bold = true }
-mode_unset = { fg = "#e0def4", bg = "#b4637a", bold = true }
+# Mode — iris for normal (calm), foam for select (active), love for unset (danger)
+mode_normal = { fg = "#232136", bg = "#c4a7e7", bold = true }
+mode_select = { fg = "#232136", bg = "#9ccfd8", bold = true }
+mode_unset  = { fg = "#e0def4", bg = "#eb6f92", bold = true }
 
 # Progress
-progress_label = { fg = "#e0def4", bold = true }
-progress_normal = { fg = "#191724", bg = "#2A273F" }
-progress_error = { fg = "#B4637A", bg = "#2A273F" }
+progress_label  = { fg = "#e0def4", bold = true }
+progress_normal = { fg = "#9ccfd8", bg = "#2a273f" }
+progress_error  = { fg = "#eb6f92", bg = "#2a273f" }
 
-# Permissions
-permissions_t = { fg = "#31748f" }
+# Permissions — pine/gold/love/foam matches conventional read/write/exec colors
+permissions_t = { fg = "#3e8fb0" }
 permissions_r = { fg = "#f6c177" }
-permissions_w = { fg = "#B4637A" }
-permissions_x = { fg = "#9ccfd8" }
-permissions_s = { fg = "#524f67" }
+permissions_w = { fg = "#eb6f92" }
+permissions_x = { fg = "#9ccfd8", bold = true }
+permissions_s = { fg = "#56526e" }
 
 # : }}}
 
@@ -66,9 +76,9 @@ permissions_s = { fg = "#524f67" }
 # : Input {{{
 
 [input]
-border = { fg = "#524f67" }
-title = {}
-value = {}
+border   = { fg = "#393552" }
+title    = { fg = "#c4a7e7", bold = true }
+value    = {}
 selected = { reversed = true }
 
 # : }}}
@@ -77,9 +87,9 @@ selected = { reversed = true }
 # : Select {{{
 
 [select]
-border = { fg = "#524f67" }
-active = { fg = "#eb6f92" }
-inactive = {}
+border   = { fg = "#393552" }
+active   = { fg = "#c4a7e7", bold = true }
+inactive = { fg = "#908caa" }
 
 # : }}}
 
@@ -87,9 +97,9 @@ inactive = {}
 # : Tasks {{{
 
 [tasks]
-border = { fg = "#524f67" }
-title = {}
-hovered = { underline = true }
+border  = { fg = "#393552" }
+title   = { fg = "#c4a7e7", bold = true }
+hovered = { bg = "#44415a", bold = true }
 
 # : }}}
 
@@ -97,12 +107,12 @@ hovered = { underline = true }
 # : Which {{{
 
 [which]
-mask = { bg = "#313244" }
-cand = { fg = "#9ccfd8" }
-rest = { fg = "#9399b2" }
-desc = { fg = "#eb6f92" }
-separator = "  "
-separator_style = { fg = "#585b70" }
+mask           = { bg = "#393552" }
+cand           = { fg = "#9ccfd8" }
+rest           = { fg = "#908caa" }
+desc           = { fg = "#c4a7e7" }
+separator      = "  "
+separator_style = { fg = "#56526e" }
 
 # : }}}
 
@@ -110,11 +120,11 @@ separator_style = { fg = "#585b70" }
 # : Help {{{
 
 [help]
-on = { fg = "#eb6f92" }
-exec = { fg = "#9ccfd8" }
-desc = { fg = "#9399b2" }
-hovered = { bg = "#585b70", bold = true }
-footer = { fg = "#2A273F", bg = "#e0def4" }
+on      = { fg = "#eb6f92" }
+exec    = { fg = "#9ccfd8" }
+desc    = { fg = "#908caa" }
+hovered = { bg = "#44415a", bold = true }
+footer  = { fg = "#2a273f", bg = "#e0def4" }
 
 # : }}}
 
@@ -122,27 +132,56 @@ footer = { fg = "#2A273F", bg = "#e0def4" }
 # : File-specific styles {{{
 
 [filetype]
-
 rules = [
-    # Images
+    # Directories — iris (purple) for clear hierarchy
+    { url = "*/", fg = "#c4a7e7", bold = true },
+
+    # Images — foam (cyan)
     { mime = "image/*", fg = "#9ccfd8" },
 
-    # Videos
+    # Video / Audio — gold (warm)
     { mime = "video/*", fg = "#f6c177" },
     { mime = "audio/*", fg = "#f6c177" },
 
-    # Archives
-    { mime = "application/zip", fg = "#eb6f92" },
-    { mime = "application/gzip", fg = "#eb6f92" },
-    { mime = "application/x-tar", fg = "#eb6f92" },
-    { mime = "application/x-bzip", fg = "#eb6f92" },
-    { mime = "application/x-bzip2", fg = "#eb6f92" },
+    # Archives — love (red/pink)
+    { mime = "application/zip",             fg = "#eb6f92" },
+    { mime = "application/gzip",            fg = "#eb6f92" },
+    { mime = "application/x-tar",           fg = "#eb6f92" },
+    { mime = "application/x-bzip",          fg = "#eb6f92" },
+    { mime = "application/x-bzip2",         fg = "#eb6f92" },
     { mime = "application/x-7z-compressed", fg = "#eb6f92" },
-    { mime = "application/x-rar", fg = "#eb6f92" },
+    { mime = "application/x-rar",           fg = "#eb6f92" },
+    { mime = "application/zstd",            fg = "#eb6f92" },
+    { mime = "application/x-xz",            fg = "#eb6f92" },
 
-    # Fallback
+    # Documents — rose (soft pink)
+    { mime = "application/pdf",                          fg = "#ea9a97" },
+    { mime = "application/msword",                       fg = "#ea9a97" },
+    { mime = "application/vnd.openxmlformats*",          fg = "#ea9a97" },
+    { mime = "application/vnd.oasis*",                   fg = "#ea9a97" },
+    { mime = "application/epub+zip",                     fg = "#ea9a97" },
+
+    # Data / Config — gold
+    { url = "*.json",  fg = "#f6c177" },
+    { url = "*.jsonc", fg = "#f6c177" },
+    { url = "*.toml",  fg = "#f6c177" },
+    { url = "*.yaml",  fg = "#f6c177" },
+    { url = "*.yml",   fg = "#f6c177" },
+    { url = "*.env",   fg = "#f6c177" },
+    { url = "*.ini",   fg = "#f6c177" },
+    { url = "*.conf",  fg = "#f6c177" },
+
+    # Scripts / Executables — pine (teal-blue)
+    { url = "*.sh",   fg = "#3e8fb0", bold = true },
+    { url = "*.bash", fg = "#3e8fb0", bold = true },
+    { url = "*.fish", fg = "#3e8fb0", bold = true },
+    { url = "*.zsh",  fg = "#3e8fb0", bold = true },
+    { url = "*.py",   fg = "#3e8fb0" },
+    { url = "*.rb",   fg = "#3e8fb0" },
+    { url = "*.pl",   fg = "#3e8fb0" },
+
+    # Fallback — text
     { url = "*", fg = "#e0def4" },
-    { url = "*/", fg = "#524f67" },
 ]
 
 # : }}}

--- a/yazi/yazi.toml
+++ b/yazi/yazi.toml
@@ -4,12 +4,12 @@
 
 [mgr]
 ratio          = [ 1, 2, 4 ]
-sort_by        = "alphabetical"
+sort_by        = "natural"
 sort_sensitive = false
-sort_reverse 	 = false
+sort_reverse   = false
 sort_dir_first = true
 sort_translit  = false
-linemode       = "none"
+linemode       = "size"
 show_hidden    = true
 show_symlink   = true
 scrolloff      = 5
@@ -30,19 +30,21 @@ ueberzug_offset = [ 0, 0, 0, 0 ]
 
 [opener]
 edit = [
-	{ run = '${EDITOR:-nvim} "$@"', desc = "$EDITOR", block = true, for = "macos" },
+	{ run = '${EDITOR:-nvim} "$@"', desc = "$EDITOR", block = true, for = "unix" },
 ]
 open = [
-	{ run = 'open "$@"',                    desc = "Open", for = "macos" },
+	{ run = 'open "$@"',     desc = "Open", for = "macos" },
+	{ run = 'xdg-open "$1"', desc = "Open", for = "linux" },
 ]
 reveal = [
-	{ run = 'open -R "$1"',                         desc = "Reveal", for = "macos" },
+	{ run = 'open -R "$1"',                     desc = "Reveal",             for = "macos" },
+	{ run = 'xdg-open "$(dirname "$1")"',        desc = "Reveal in manager",  for = "linux" },
 ]
 extract = [
-	{ run = 'ya pub extract --list "$@"', desc = "Extract here", for = "macos" },
+	{ run = 'ya pub extract --list "$@"', desc = "Extract here" },
 ]
 play = [
-	{ run = 'mpv --force-window "$@"', orphan = true, for = "macos" },
+	{ run = 'mpv --force-window "$@"', orphan = true, for = "unix" },
 ]
 
 [open]


### PR DESCRIPTION
- theme: fix all non-Moon rose pine colors (b4637a, 31748f, ebbcba, 26233a, catppuccin leftovers)
- theme: directories now iris (#c4a7e7) for clear visual hierarchy vs files
- theme: mode_normal uses iris bg to match starship directory segment
- theme: active tabs brighter than inactive (was inverted), better contrast
- theme: [which] and [help] popups fully consistent rose pine moon
- theme: input/select/tasks borders and titles use overlay/iris
- theme: expanded filetype rules — documents (rose), configs (gold), scripts (pine), archives (love)
- yazi: sort_by = "natural" for better handling of numbered files/dirs
- yazi: linemode = "size" to show file sizes at a glance by default
- yazi: add linux openers (xdg-open, unix-wide edit/play); extract is now cross-platform
- keymap: add goto shortcuts gD Desktop, go Documents, gp Pictures, gm Music, gv Videos, gt /tmp, ge /etc

https://claude.ai/code/session_011e1jEr2sU6mh2zWzDEyUeh