### PR TITLE
feat(nvim): improve debugging support for python, go, and rust

### DIFF
--- a/nvim/lua/plugins/dap.lua
+++ b/nvim/lua/plugins/dap.lua
@@ -7,7 +7,7 @@ return {
     'leoluz/nvim-dap-go',
     'mfussenegger/nvim-dap-python',
   },
-  ft = { 'go', 'python' },
+  ft = { 'go', 'python', 'rust' },
   keys = {
     {
       '<leader>dc',
@@ -40,6 +40,11 @@ return {
       desc = 'Debug: Set Conditional Breakpoint',
     },
     {
+      '<leader>dL',
+      function() require('dap').set_breakpoint(nil, nil, vim.fn.input('Log message: ')) end,
+      desc = 'Debug: Log Breakpoint',
+    },
+    {
       '<leader>dt',
       function() require('dapui').toggle() end,
       desc = 'Debug: Toggle UI',
@@ -48,6 +53,22 @@ return {
       '<leader>dl',
       function() require('dap').run_last() end,
       desc = 'Debug: Run Last Configuration',
+    },
+    {
+      '<leader>dr',
+      function() require('dap').repl.open() end,
+      desc = 'Debug: Open REPL',
+    },
+    {
+      '<leader>de',
+      function() require('dapui').eval() end,
+      desc = 'Debug: Evaluate Expression',
+      mode = { 'n', 'v' },
+    },
+    {
+      '<leader>dx',
+      function() require('dap').terminate() end,
+      desc = 'Debug: Terminate',
     },
   },
   config = function()
@@ -75,10 +96,60 @@ return {
     dap.listeners.before.event_terminated['dapui_config'] = dapui.close
     dap.listeners.before.event_exited['dapui_config'] = dapui.close
 
-    require('nvim-dap-virtual-text').setup()
+    require('nvim-dap-virtual-text').setup({
+      commented = true,
+    })
 
+    -- Python
     local dappython = require('dap-python')
     dappython.setup('uv')
     dappython.test_runner = 'pytest'
+
+    -- Go
+    require('dap-go').setup()
+
+    -- Rust (codelldb via Mason)
+    local ok, registry = pcall(require, 'mason-registry')
+    local codelldb_cmd = 'codelldb'
+    if ok and registry.is_installed('codelldb') then
+      local pkg = registry.get_package('codelldb')
+      codelldb_cmd = pkg:get_install_path() .. '/extension/adapter/codelldb'
+    end
+
+    dap.adapters.codelldb = {
+      type = 'server',
+      port = '${port}',
+      executable = {
+        command = codelldb_cmd,
+        args = { '--port', '${port}' },
+      },
+    }
+
+    dap.configurations.rust = {
+      {
+        name = 'Launch binary',
+        type = 'codelldb',
+        request = 'launch',
+        program = function()
+          return vim.fn.input('Path to executable: ', vim.fn.getcwd() .. '/target/debug/', 'file')
+        end,
+        cwd = '${workspaceFolder}',
+        stopOnEntry = false,
+      },
+      {
+        name = 'Launch binary (with args)',
+        type = 'codelldb',
+        request = 'launch',
+        program = function()
+          return vim.fn.input('Path to executable: ', vim.fn.getcwd() .. '/target/debug/', 'file')
+        end,
+        args = function()
+          local args = vim.fn.input('Args: ')
+          return vim.split(args, ' ', { trimempty = true })
+        end,
+        cwd = '${workspaceFolder}',
+        stopOnEntry = false,
+      },
+    }
   end,
 }

--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -16,6 +16,7 @@ return {
         build = {
           ':MasonUpdate',
           ':MasonInstall basedpyright',
+          ':MasonInstall codelldb',
           ':MasonInstall debugpy',
           ':MasonInstall delve',
           ':MasonInstall gitlint',


### PR DESCRIPTION
- Fix Go debugging: add missing require('dap-go').setup() call
- Add Rust debugging via codelldb (installed through Mason), with two
  launch configs (plain and with args)
- Add codelldb to Mason auto-install list
- Add new debug keymaps: log breakpoint (<leader>dL), REPL (<leader>dr),
  evaluate expression (<leader>de, visual+normal), terminate (<leader>dx)
- Enable commented=true in nvim-dap-virtual-text to prevent inline
  variable values from obscuring code

https://claude.ai/code/session_01JePh28kpZosUt1aoPxX2or