### PR TITLE
install: add recommended TUI/CLI tools across install scripts

### DIFF
--- a/install/devops.sh
+++ b/install/devops.sh
@@ -11,17 +11,21 @@ FORMULAS=(
     datawire/blackbird/telepresence
     derailed/k9s/k9s
     derailed/popeye/popeye
+    wagoodman/brew/dive # TUI Docker image layer explorer
     fluxcd/tap/flux
     hadolint
     helm
     istioctl
+    jesseduffield/lazydocker/lazydocker # TUI for Docker (companion to lazygit)
     kind
     krew
+    kubecolor   # colorizes kubectl output (drop-in replacement)
     kubeconform
     kubectx
     kubeseal
     kustomize
     stern
+    termshark # TUI frontend for tshark/Wireshark packet analysis
     terraform
     terraform-docs
     terragrunt

--- a/install/minimal.sh
+++ b/install/minimal.sh
@@ -9,6 +9,7 @@ TAPS=(
 )
 
 FORMULAS=(
+    atuin # shell history replacement with full-text search, timestamps, and stats
     bash
     btop
     colima
@@ -17,6 +18,8 @@ FORMULAS=(
     delta
     diffutils
     direnv
+    duf   # df replacement with color-coded disk usage overview
+    dust  # du replacement with tree visualization
     docker
     fd # find replacement
     findutils
@@ -47,6 +50,7 @@ FORMULAS=(
     nvtop
     pidof
     pstree
+    procs # ps replacement with color, tree view, and filtering
     rename
     ripgrep
     rsync
@@ -57,6 +61,7 @@ FORMULAS=(
     tmux
     tree
     watch
+    viddy # watch replacement with diff highlighting and TUI
     oha  # rust-based HTTP benchmarker with TUI histogram (replaces wrk)
     wget
     xo/xo/usql

--- a/install/util.sh
+++ b/install/util.sh
@@ -11,6 +11,7 @@ TAPS=(
 )
 
 FORMULAS=(
+    ast-grep # structural code search and replace using AST patterns
     bat # cat replacement with line numbers and syntax highlighting
     calc
     cloc
@@ -21,14 +22,21 @@ FORMULAS=(
     glow # markdown renderer with pager support (replaces mdcat)
     go-task
     graphviz
+    gum       # shell script UI components (prompts, spinners, confirms)
+    harlequin # TUI SQL IDE (DuckDB, Postgres, SQLite)
     hurl # scriptable HTTP request runner (.hurl files)
+    hyperfine # statistical CLI benchmarking tool
+    jless # TUI pager for JSON navigation
     jo
     lua
     luajit
     mandoc
+    navi     # interactive cheatsheet tool with fzf integration
+    posting  # TUI HTTP client with collections and history
     pv
     ragel
     rclone
+    serpl      # TUI find-and-replace across files
     shellcheck
     terminal-notifier
     trash


### PR DESCRIPTION
Adds 17 tools identified as fitting the existing workflow preferences:

minimal.sh: atuin (shell history), duf (df replacement), dust (du replacement),
procs (ps replacement), viddy (watch replacement with diff highlighting)

util.sh: ast-grep (structural code search/replace), gum (shell script UI),
harlequin (TUI SQL IDE), hyperfine (benchmarking), jless (JSON pager),
navi (interactive cheatsheets + fzf), posting (TUI HTTP client),
serpl (TUI find-and-replace)

devops.sh: dive (Docker image layer explorer), lazydocker (Docker TUI),
kubecolor (colorized kubectl output), termshark (TUI packet analyzer)

https://claude.ai/code/session_015n84BGwbVVoqa7wF6vuiMb