### PR TITLE
Add Rust install script with CLI/TUI/dev tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,10 @@ python: brew ## install Python3 toolchain
 go: brew ## install Go toolchain
 	@sh ./install/go.sh
 
+.PHONY: rust
+rust: brew ## install Rust toolchain
+	@sh ./install/rust.sh
+
 .PHONY: devops
 devops: brew ## install devops toolchain
 	@sh ./install/devops.sh

--- a/README.md
+++ b/README.md
@@ -34,5 +34,6 @@ Install Targets
 | `util`    | Utilities via Homebrew             |
 | `python`  | Python3 toolchain                  |
 | `go`      | Go toolchain                       |
+| `rust`    | Rust toolchain                     |
 | `devops`  | DevOps toolchain                   |
 | `qmk`     | QMK keyboard firmware dev chain    |

--- a/install/rust.sh
+++ b/install/rust.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+PATH=/usr/local/bin:$PATH
+
+source "${BASH_SOURCE%/*}/lib.sh"
+
+CRATES=(
+    cargo-edit      # cargo add/rm/upgrade for dependency management
+    cargo-watch     # watch files and re-run commands on change
+    cargo-nextest   # next-gen test runner (faster, better output)
+    cargo-audit     # audit dependencies for security vulnerabilities
+    cargo-outdated  # check for outdated dependencies
+    cargo-expand    # expand macros for debugging
+    bacon           # background code checker TUI
+    bottom          # cross-platform TUI system monitor (btm)
+    tokei           # fast code statistics
+)
+
+FORMULAS=(
+    rustup
+)
+
+h1 "rust"
+h2 "brew formulas"
+for f in "${FORMULAS[@]}"; do brew_install "$f"; done
+h2 "cargo crates"
+for c in "${CRATES[@]}"; do cargo_install "$c"; done


### PR DESCRIPTION
Adds install/rust.sh following the same pattern as go.sh and python.sh.
Installs rustup via Homebrew and a curated set of cargo crates:
cargo-edit, cargo-watch, cargo-nextest, cargo-audit, cargo-outdated,
cargo-expand, bacon, bottom, and tokei. Updates Makefile and README.

https://claude.ai/code/session_01MnSeaSugQMLP537Te2mf2d