### PR TITLE
Add configs for 10 CLI/TUI tools with rose-pine-moon theming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ FILES=\
 	hushlogin	\
 	mackup		\
 	mackup.cfg	\
-	rpignore	\
+	rgignore	\
+	ripgreprc	\
 	starship.toml	\
 	tmux.conf	\
 	wgetrc
@@ -22,12 +23,20 @@ MAKEDIRS=\
 	$(XDG_DATA_HOME)/nvim/undo
 
 CONFIGS=\
+	atuin		\
 	bat		\
+	btop		\
+	direnv		\
 	fish		\
+	harlequin	\
+	k9s		\
 	kitty		\
+	lazydocker	\
 	lazygit		\
+	navi		\
 	nvim		\
 	opencode	\
+	posting		\
 	tmux		\
 	wtf		\
 	yazi

--- a/atuin/config.toml
+++ b/atuin/config.toml
@@ -1,0 +1,47 @@
+# Rose Pine Moon — atuin configuration
+# https://github.com/atuinsh/atuin
+
+dialect = "us"
+auto_sync = false
+update_check = false
+sync_frequency = "1h"
+sync_address = "https://api.atuin.sh"
+
+# Search
+search_mode = "fuzzy"
+filter_mode = "global"
+filter_mode_shell_up_key_binding = "session"
+
+# UI
+style = "compact"
+inline_height = 20
+show_preview = true
+max_preview_height = 4
+show_help = false
+show_tabs = true
+exit_mode = "return-query"
+enter_accept = false
+
+# History
+history_filter = [
+  "^ls$",
+  "^cd$",
+  "^pwd$",
+  "^clear$",
+  "^exit$",
+]
+
+[stats]
+common_subcommands = [
+  "cargo",
+  "docker",
+  "fish",
+  "git",
+  "go",
+  "helm",
+  "kubectl",
+  "nvim",
+  "terraform",
+  "brew",
+]
+common_prefix = ["sudo"]

--- a/bat/config
+++ b/bat/config
@@ -1,0 +1,14 @@
+# bat configuration
+# https://github.com/sharkdp/bat
+
+--theme="rose-pine-moon"
+--style="numbers,changes,header-filename"
+--italic-text=always
+--paging=never
+--color=always
+
+--map-syntax="*.conf:INI"
+--map-syntax="*.env:Bash"
+--map-syntax="*.envrc:Bash"
+--map-syntax="Makefile:Makefile"
+--map-syntax="*.toml:TOML"

--- a/bat/themes/rose-pine-moon.tmTheme
+++ b/bat/themes/rose-pine-moon.tmTheme
@@ -1,0 +1,413 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<!--
+  Rose Pine Moon — bat theme
+  https://rosepinetheme.com/palette/ingredients
+
+  base     = #232136   surface  = #2a273f   overlay  = #393552
+  muted    = #6e6a86   subtle   = #908caa   text     = #e0def4
+  love     = #eb6f92   gold     = #f6c177   rose     = #ea9a97
+  pine     = #3e8fb0   foam     = #9ccfd8   iris     = #c4a7e7
+  hl-low   = #2a283e   hl-med   = #44415a   hl-high  = #56526e
+-->
+<dict>
+  <key>name</key>
+  <string>rose-pine-moon</string>
+  <key>settings</key>
+  <array>
+    <dict>
+      <key>settings</key>
+      <dict>
+        <key>background</key>
+        <string>#232136</string>
+        <key>foreground</key>
+        <string>#e0def4</string>
+        <key>caret</key>
+        <string>#e0def4</string>
+        <key>selection</key>
+        <string>#44415a</string>
+        <key>selectionForeground</key>
+        <string>#e0def4</string>
+        <key>lineHighlight</key>
+        <string>#2a283e</string>
+        <key>findHighlight</key>
+        <string>#f6c177</string>
+        <key>findHighlightForeground</key>
+        <string>#232136</string>
+        <key>bracketsForeground</key>
+        <string>#908caa</string>
+        <key>bracketsOptions</key>
+        <string>underline</string>
+      </dict>
+    </dict>
+
+    <!-- Comment -->
+    <dict>
+      <key>name</key>
+      <string>Comment</string>
+      <key>scope</key>
+      <string>comment, punctuation.definition.comment</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#6e6a86</string>
+        <key>fontStyle</key>
+        <string>italic</string>
+      </dict>
+    </dict>
+
+    <!-- String -->
+    <dict>
+      <key>name</key>
+      <string>String</string>
+      <key>scope</key>
+      <string>string, string.quoted, string.template</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#9ccfd8</string>
+      </dict>
+    </dict>
+
+    <!-- String escape -->
+    <dict>
+      <key>name</key>
+      <string>String Escape</string>
+      <key>scope</key>
+      <string>constant.character.escape, string.regexp</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#eb6f92</string>
+      </dict>
+    </dict>
+
+    <!-- Number -->
+    <dict>
+      <key>name</key>
+      <string>Number</string>
+      <key>scope</key>
+      <string>constant.numeric</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#f6c177</string>
+      </dict>
+    </dict>
+
+    <!-- Constant -->
+    <dict>
+      <key>name</key>
+      <string>Constant</string>
+      <key>scope</key>
+      <string>constant, constant.language, constant.other</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#f6c177</string>
+      </dict>
+    </dict>
+
+    <!-- Keyword -->
+    <dict>
+      <key>name</key>
+      <string>Keyword</string>
+      <key>scope</key>
+      <string>keyword, keyword.control, keyword.operator</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#3e8fb0</string>
+      </dict>
+    </dict>
+
+    <!-- Keyword declaration -->
+    <dict>
+      <key>name</key>
+      <string>Keyword Declaration</string>
+      <key>scope</key>
+      <string>keyword.declaration, storage, storage.type, storage.modifier</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#3e8fb0</string>
+        <key>fontStyle</key>
+        <string>italic</string>
+      </dict>
+    </dict>
+
+    <!-- Variable -->
+    <dict>
+      <key>name</key>
+      <string>Variable</string>
+      <key>scope</key>
+      <string>variable, variable.other, variable.language</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#e0def4</string>
+      </dict>
+    </dict>
+
+    <!-- Variable parameter -->
+    <dict>
+      <key>name</key>
+      <string>Parameter</string>
+      <key>scope</key>
+      <string>variable.parameter</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#ea9a97</string>
+        <key>fontStyle</key>
+        <string>italic</string>
+      </dict>
+    </dict>
+
+    <!-- Function name -->
+    <dict>
+      <key>name</key>
+      <string>Function Name</string>
+      <key>scope</key>
+      <string>entity.name.function, meta.function-call.generic, support.function</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#9ccfd8</string>
+      </dict>
+    </dict>
+
+    <!-- Type -->
+    <dict>
+      <key>name</key>
+      <string>Type</string>
+      <key>scope</key>
+      <string>entity.name.type, entity.name.class, support.type, support.class</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#f6c177</string>
+      </dict>
+    </dict>
+
+    <!-- Tag -->
+    <dict>
+      <key>name</key>
+      <string>Tag</string>
+      <key>scope</key>
+      <string>entity.name.tag, punctuation.definition.tag</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#eb6f92</string>
+      </dict>
+    </dict>
+
+    <!-- Tag attribute -->
+    <dict>
+      <key>name</key>
+      <string>Tag Attribute</string>
+      <key>scope</key>
+      <string>entity.other.attribute-name</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#c4a7e7</string>
+      </dict>
+    </dict>
+
+    <!-- Punctuation -->
+    <dict>
+      <key>name</key>
+      <string>Punctuation</string>
+      <key>scope</key>
+      <string>punctuation, punctuation.separator, punctuation.terminator</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#908caa</string>
+      </dict>
+    </dict>
+
+    <!-- Operator -->
+    <dict>
+      <key>name</key>
+      <string>Operator</string>
+      <key>scope</key>
+      <string>keyword.operator.assignment, keyword.operator.comparison, keyword.operator.logical, keyword.operator.arithmetic</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#eb6f92</string>
+      </dict>
+    </dict>
+
+    <!-- Import / include -->
+    <dict>
+      <key>name</key>
+      <string>Import</string>
+      <key>scope</key>
+      <string>keyword.control.import, keyword.control.from, keyword.control.include, meta.import</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#c4a7e7</string>
+      </dict>
+    </dict>
+
+    <!-- Namespace / module -->
+    <dict>
+      <key>name</key>
+      <string>Namespace</string>
+      <key>scope</key>
+      <string>entity.name.namespace, entity.name.module, support.other.namespace</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#f6c177</string>
+      </dict>
+    </dict>
+
+    <!-- Property key (JSON/YAML/TOML) -->
+    <dict>
+      <key>name</key>
+      <string>Property Key</string>
+      <key>scope</key>
+      <string>support.type.property-name, meta.mapping.key string, meta.object-literal.key</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#9ccfd8</string>
+      </dict>
+    </dict>
+
+    <!-- Boolean -->
+    <dict>
+      <key>name</key>
+      <string>Boolean</string>
+      <key>scope</key>
+      <string>constant.language.boolean</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#3e8fb0</string>
+      </dict>
+    </dict>
+
+    <!-- Invalid -->
+    <dict>
+      <key>name</key>
+      <string>Invalid</string>
+      <key>scope</key>
+      <string>invalid, invalid.illegal</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#eb6f92</string>
+        <key>fontStyle</key>
+        <string>underline</string>
+      </dict>
+    </dict>
+
+    <!-- Diff inserted -->
+    <dict>
+      <key>name</key>
+      <string>Diff Inserted</string>
+      <key>scope</key>
+      <string>markup.inserted</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#9ccfd8</string>
+      </dict>
+    </dict>
+
+    <!-- Diff deleted -->
+    <dict>
+      <key>name</key>
+      <string>Diff Deleted</string>
+      <key>scope</key>
+      <string>markup.deleted</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#eb6f92</string>
+      </dict>
+    </dict>
+
+    <!-- Markup heading -->
+    <dict>
+      <key>name</key>
+      <string>Markup Heading</string>
+      <key>scope</key>
+      <string>markup.heading, entity.name.section</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#c4a7e7</string>
+        <key>fontStyle</key>
+        <string>bold</string>
+      </dict>
+    </dict>
+
+    <!-- Markup bold -->
+    <dict>
+      <key>name</key>
+      <string>Markup Bold</string>
+      <key>scope</key>
+      <string>markup.bold</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#f6c177</string>
+        <key>fontStyle</key>
+        <string>bold</string>
+      </dict>
+    </dict>
+
+    <!-- Markup italic -->
+    <dict>
+      <key>name</key>
+      <string>Markup Italic</string>
+      <key>scope</key>
+      <string>markup.italic</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#ea9a97</string>
+        <key>fontStyle</key>
+        <string>italic</string>
+      </dict>
+    </dict>
+
+    <!-- Markup link -->
+    <dict>
+      <key>name</key>
+      <string>Markup Link</string>
+      <key>scope</key>
+      <string>markup.underline.link, string.other.link</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#3e8fb0</string>
+        <key>fontStyle</key>
+        <string>underline</string>
+      </dict>
+    </dict>
+
+    <!-- Markup code -->
+    <dict>
+      <key>name</key>
+      <string>Markup Inline Code</string>
+      <key>scope</key>
+      <string>markup.inline.raw, markup.raw.block</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#9ccfd8</string>
+      </dict>
+    </dict>
+  </array>
+</dict>
+</plist>

--- a/btop/btop.conf
+++ b/btop/btop.conf
@@ -1,0 +1,69 @@
+#? Config file for btop v. 1.3.x
+
+# Rose Pine Moon theme (themes dir is resolved from XDG_CONFIG_HOME/btop/themes)
+color_theme = "rose-pine-moon"
+theme_background = True
+truecolor = True
+force_tty = False
+
+# UI
+vim_keys = True
+rounded_corners = True
+graph_symbol = "braille"
+graph_symbol_cpu = "default"
+graph_symbol_gpu = "default"
+graph_symbol_mem = "default"
+graph_symbol_net = "default"
+graph_symbol_proc = "default"
+
+# Layout
+shown_boxes = "cpu mem net proc"
+update_ms = 2000
+
+# Process view
+proc_sorting = "cpu lazy"
+proc_reversed = False
+proc_tree = False
+proc_colors = True
+proc_gradient = True
+proc_per_core = True
+proc_mem_bytes = True
+proc_cpu_graphs = True
+proc_info_smaps = False
+proc_left = False
+proc_filter_kernel = False
+
+# CPU
+cpu_graph_upper = "total"
+cpu_graph_lower = "user"
+cpu_invert_lower = True
+cpu_single_graph = False
+cpu_bottom = False
+show_cpu_freq = True
+clock_format = "%X"
+background_update = True
+custom_cpu_name = ""
+disks_filter = ""
+
+# Memory
+mem_graphs = True
+mem_below_net = False
+zfs_arc_cached = True
+
+# Network
+net_download = 100
+net_upload = 100
+net_auto = True
+net_sync = False
+net_iface = ""
+
+# Battery
+show_battery = True
+selected_battery = "Auto"
+show_battery_watts = True
+
+# Misc
+log_level = "WARNING"
+base_10_sizes = False
+show_coretemp = True
+gpu_mirror_graph = True

--- a/btop/themes/rose-pine-moon.theme
+++ b/btop/themes/rose-pine-moon.theme
@@ -1,0 +1,67 @@
+# Rose Pine Moon — btop theme
+# https://rosepinetheme.com/palette/ingredients
+#
+# base     = #232136   surface  = #2a273f   overlay  = #393552
+# muted    = #6e6a86   subtle   = #908caa   text     = #e0def4
+# love     = #eb6f92   gold     = #f6c177   rose     = #ea9a97
+# pine     = #3e8fb0   foam     = #9ccfd8   iris     = #c4a7e7
+# hl-low   = #2a283e   hl-med   = #44415a   hl-high  = #56526e
+
+# Main colors
+theme[main_bg]="#232136"        # base
+theme[main_fg]="#e0def4"        # text
+theme[title]="#c4a7e7"          # iris
+theme[hi_fg]="#9ccfd8"          # foam
+theme[selected_bg]="#44415a"    # hl-med
+theme[selected_fg]="#e0def4"    # text
+theme[inactive_fg]="#6e6a86"    # muted
+theme[graph_text]="#908caa"     # subtle
+theme[meter_bg]="#393552"       # overlay
+theme[proc_misc]="#f6c177"      # gold
+
+# Box border colors
+theme[cpu_box]="#3e8fb0"        # pine
+theme[mem_box]="#c4a7e7"        # iris
+theme[net_box]="#9ccfd8"        # foam
+theme[proc_box]="#ea9a97"       # rose
+theme[div_line]="#393552"       # overlay
+
+# Temperature gradient: cool → warm → hot
+theme[temp_start]="#9ccfd8"     # foam
+theme[temp_mid]="#f6c177"       # gold
+theme[temp_end]="#eb6f92"       # love
+
+# CPU graph gradient
+theme[cpu_start]="#9ccfd8"      # foam
+theme[cpu_mid]="#c4a7e7"        # iris
+theme[cpu_end]="#eb6f92"        # love
+
+# Memory free gradient
+theme[free_start]="#9ccfd8"     # foam
+theme[free_mid]="#f6c177"       # gold
+theme[free_end]="#eb6f92"       # love
+
+# Memory cached gradient
+theme[cached_start]="#9ccfd8"   # foam
+theme[cached_mid]="#c4a7e7"     # iris
+theme[cached_end]="#3e8fb0"     # pine
+
+# Memory available gradient
+theme[available_start]="#9ccfd8" # foam
+theme[available_mid]="#f6c177"   # gold
+theme[available_end]="#eb6f92"   # love
+
+# Memory used gradient
+theme[used_start]="#c4a7e7"     # iris
+theme[used_mid]="#ea9a97"       # rose
+theme[used_end]="#eb6f92"       # love
+
+# Net download gradient
+theme[download_start]="#9ccfd8" # foam
+theme[download_mid]="#3e8fb0"   # pine
+theme[download_end]="#c4a7e7"   # iris
+
+# Net upload gradient
+theme[upload_start]="#ea9a97"   # rose
+theme[upload_mid]="#eb6f92"     # love
+theme[upload_end]="#f6c177"     # gold

--- a/direnv/direnvrc
+++ b/direnv/direnvrc
@@ -1,0 +1,31 @@
+# direnv stdlib extensions
+# Loaded automatically from $XDG_CONFIG_HOME/direnv/direnvrc
+# https://direnv.net/man/direnvrc.1.html
+
+# Python: create/activate venv via uv
+layout_python-uv() {
+  local python=${1:-python3}
+  local venv=.venv
+  if [[ ! -d "$venv" ]]; then
+    log_status "creating virtualenv with uv"
+    uv venv --python "$python" "$venv"
+  fi
+  source "$venv/bin/activate"
+  export VIRTUAL_ENV="$PWD/$venv"
+  export UV_PROJECT_ENVIRONMENT="$PWD/$venv"
+}
+
+# Go: isolate GOPATH per project
+layout_go() {
+  export GOPATH="$PWD/.gopath"
+  export PATH="$GOPATH/bin:$PATH"
+  mkdir -p "$GOPATH/src" "$GOPATH/bin"
+}
+
+# Node: add local node_modules/.bin to PATH
+layout_node() {
+  export PATH="$PWD/node_modules/.bin:$PATH"
+}
+
+# Shorthand aliases
+use_python() { layout python-uv "$@"; }

--- a/fish/config.fish
+++ b/fish/config.fish
@@ -43,6 +43,7 @@ set -x VIRTUAL_ENV_DISABLE_PROMPT 1
 set -x XZ_OPT '-T0'
 set -x TG_TF_FORWARD_STDOUT true
 set -x USE_GKE_GCLOUD_AUTH_PLUGIN True
+set -x RIPGREP_CONFIG_PATH $HOME/.ripgreprc
 
 # Python
 set -x POETRY_VIRTUALENVS_IN_PROJECT true
@@ -81,6 +82,12 @@ if status is-interactive
 
     # Direnv
     __cached_source direnv direnv hook fish
+
+    # Atuin (shell history)
+    __cached_source atuin atuin init fish --disable-up-arrow
+
+    # Navi (interactive cheatsheet widget)
+    __cached_source navi navi widget fish
 
     # Pyenv completions
     if set -q __PYENV_PREFIX

--- a/gitconfig
+++ b/gitconfig
@@ -222,6 +222,10 @@
     syntax-theme = Nord
     navigate = true
     hyperlinks = true
+    side-by-side = true
+    diff-stat-align-width = 48
+    true-color = always
+    paging = auto
 
     # palette
     thm-base = "#232136"

--- a/harlequin/config.toml
+++ b/harlequin/config.toml
@@ -1,0 +1,10 @@
+# Rose Pine Moon — harlequin configuration
+# https://harlequin.sh
+# harlequin ships with rose-pine built-in
+
+[harlequin]
+theme = "rose-pine"
+show_files = true
+show_s3 = false
+limit = 100_000
+locale = "en_US.UTF-8"

--- a/k9s/config.yaml
+++ b/k9s/config.yaml
@@ -1,0 +1,37 @@
+k9s:
+  liveViewAutoRefresh: true
+  refreshRate: 2
+  maxConnRetry: 5
+  readOnly: false
+  noExitOnCtrlC: false
+  ui:
+    enableMouse: false
+    headless: false
+    logoless: true
+    crumbsless: false
+    reactive: true
+    noIcons: false
+    skin: rose-pine-moon
+    defaultsToFullScreen: false
+  skipLatestRevCheck: false
+  shellPod:
+    image: busybox:1.35.0
+    namespace: default
+    limits:
+      cpu: 100m
+      memory: 100Mi
+  imageScans:
+    enable: false
+  logger:
+    tail: 100
+    buffer: 5000
+    sinceSeconds: -1
+    textWrap: false
+    showTime: false
+  thresholds:
+    cpu:
+      critical: 90
+      warn: 70
+    memory:
+      critical: 90
+      warn: 70

--- a/k9s/skins/rose-pine-moon.yaml
+++ b/k9s/skins/rose-pine-moon.yaml
@@ -1,0 +1,102 @@
+# Rose Pine Moon — k9s skin
+# https://rosepinetheme.com/palette/ingredients
+#
+# base     = #232136   surface  = #2a273f   overlay  = #393552
+# muted    = #6e6a86   subtle   = #908caa   text     = #e0def4
+# love     = #eb6f92   gold     = #f6c177   rose     = #ea9a97
+# pine     = #3e8fb0   foam     = #9ccfd8   iris     = #c4a7e7
+# hl-low   = #2a283e   hl-med   = #44415a   hl-high  = #56526e
+
+k9s:
+  body:
+    fgColor: '#e0def4'       # text
+    bgColor: '#232136'       # base
+    logoColor: '#c4a7e7'     # iris
+
+  prompt:
+    fgColor: '#e0def4'       # text
+    bgColor: '#2a273f'       # surface
+    suggestColor: '#908caa'  # subtle
+
+  info:
+    fgColor: '#9ccfd8'       # foam
+    sectionColor: '#e0def4'  # text
+
+  dialog:
+    fgColor: '#e0def4'       # text
+    bgColor: '#2a273f'       # surface
+    buttonFgColor: '#232136' # base
+    buttonBgColor: '#c4a7e7' # iris
+    buttonFocusFgColor: '#232136' # base
+    buttonFocusBgColor: '#9ccfd8' # foam
+    labelFgColor: '#f6c177'  # gold
+    fieldFgColor: '#e0def4'  # text
+
+  frame:
+    border:
+      fgColor: '#393552'     # overlay
+      focusColor: '#9ccfd8'  # foam
+    menu:
+      fgColor: '#e0def4'     # text
+      keyColor: '#c4a7e7'    # iris
+      numFgColor: '#f6c177'  # gold
+    crumbs:
+      fgColor: '#232136'     # base
+      bgColor: '#9ccfd8'     # foam
+      activeColor: '#c4a7e7' # iris
+    status:
+      newColor: '#9ccfd8'    # foam
+      modifyColor: '#c4a7e7' # iris
+      addColor: '#9ccfd8'    # foam
+      errorColor: '#eb6f92'  # love
+      highlightColor: '#f6c177' # gold
+      killColor: '#eb6f92'   # love
+      completedColor: '#6e6a86' # muted
+    title:
+      fgColor: '#e0def4'     # text
+      bgColor: '#232136'     # base
+      highlightColor: '#c4a7e7' # iris
+      counterColor: '#9ccfd8' # foam
+      filterColor: '#f6c177' # gold
+
+  views:
+    charts:
+      bgColor: default
+      chartBgColor: default
+      dialBgColor: default
+      defaultDialColors:
+        ok: '#9ccfd8'        # foam
+        warn: '#f6c177'      # gold
+        critical: '#eb6f92'  # love
+      defaultChartColors:
+        ok: '#9ccfd8'        # foam
+        warn: '#f6c177'      # gold
+        critical: '#eb6f92'  # love
+    table:
+      fgColor: '#e0def4'     # text
+      bgColor: '#232136'     # base
+      markColor: '#f6c177'   # gold
+      header:
+        fgColor: '#9ccfd8'   # foam
+        bgColor: '#232136'   # base
+        sorterColor: '#c4a7e7' # iris
+    xray:
+      fgColor: '#e0def4'     # text
+      bgColor: '#232136'     # base
+      cursorColor: '#44415a' # hl-med
+      graphicColor: '#c4a7e7' # iris
+      showIcons: false
+    yaml:
+      keyColor: '#c4a7e7'    # iris
+      colonColor: '#6e6a86'  # muted
+      valueColor: '#e0def4'  # text
+      rootKeyColor: '#9ccfd8' # foam
+      headerColor: '#f6c177' # gold
+    logs:
+      fgColor: '#e0def4'     # text
+      bgColor: '#232136'     # base
+      indicator:
+        fgColor: '#9ccfd8'   # foam
+        bgColor: '#232136'   # base
+        toggleOnColor: '#9ccfd8'  # foam
+        toggleOffColor: '#6e6a86' # muted

--- a/lazydocker/config.yml
+++ b/lazydocker/config.yml
@@ -1,0 +1,48 @@
+# Rose Pine Moon — lazydocker configuration
+# https://rosepinetheme.com/palette/ingredients
+#
+# base     = #232136   surface  = #2a273f   overlay  = #393552
+# muted    = #6e6a86   subtle   = #908caa   text     = #e0def4
+# love     = #eb6f92   gold     = #f6c177   rose     = #ea9a97
+# pine     = #3e8fb0   foam     = #9ccfd8   iris     = #c4a7e7
+# hl-low   = #2a283e   hl-med   = #44415a   hl-high  = #56526e
+
+gui:
+  scrollHeight: 2
+  language: auto
+  mouseEvents: false
+  returnImmediately: false
+  wrapMainPanel: true
+  theme:
+    activeBorderColor:
+      - '#9ccfd8'  # foam
+      - bold
+    inactiveBorderColor:
+      - '#393552'  # overlay
+    optionsTextColor:
+      - '#c4a7e7'  # iris
+    selectedLineBgColor:
+      - '#44415a'  # hl-med
+    selectedRangeBgColor:
+      - '#44415a'  # hl-med
+    headerBgColor:
+      - '#2a273f'  # surface
+    unstagedChangesColor:
+      - '#eb6f92'  # love
+    defaultFgColor:
+      - '#e0def4'  # text
+
+logs:
+  timestamps: false
+  since: '60m'
+  tail: 200
+
+commandTemplates:
+  dockerCompose: docker compose
+
+stats:
+  graphs:
+    - stat: cpu
+      color: '#9ccfd8'   # foam
+    - stat: memory
+      color: '#c4a7e7'   # iris

--- a/navi/config.yaml
+++ b/navi/config.yaml
@@ -1,0 +1,33 @@
+# Rose Pine Moon — navi configuration
+# https://github.com/denisidoro/navi
+
+cheats:
+  paths:
+    - ~/.config/navi/cheats
+
+finder:
+  # Use the same FZF colors as the rest of the environment
+  command: fzf
+  overrides: >
+    --color=fg:#908caa,bg:-1,hl:#ea9a97
+    --color=fg+:#e0def4,bg+:#393552,hl+:#ea9a97
+    --color=border:#6e6a86,header:#3e8fb0,gutter:#232136
+    --color=spinner:#f6c177,info:#9ccfd8,separator:#44415a
+    --color=pointer:#c4a7e7,marker:#eb6f92,prompt:#908caa
+    --border=none
+    --prompt="  "
+    --height=60%
+    --info=inline
+    --tiebreak=end,length
+
+style:
+  tag:
+    color: cyan
+    width_percentage: 26
+    min_width: 20
+  comment:
+    color: blue
+    width_percentage: 42
+    min_width: 45
+  snippet:
+    color: white

--- a/posting/config.yaml
+++ b/posting/config.yaml
@@ -1,0 +1,20 @@
+# Rose Pine Moon — posting configuration
+# https://github.com/darrenburns/posting
+# posting ships with rose-pine built-in
+
+theme: rose-pine
+text_area_theme: monokai
+layout: horizontal
+use_host_environment: true
+
+response:
+  prettify_json: true
+
+heading:
+  visible: true
+
+collection_browser:
+  position: left
+
+animation:
+  enabled: false

--- a/ripgreprc
+++ b/ripgreprc
@@ -1,0 +1,21 @@
+# ripgrep configuration
+# https://github.com/BurntSushi/ripgrep/blob/master/GUIDE.md#configuration-file
+# Loaded via RIPGREP_CONFIG_PATH (set in fish/config.fish)
+
+# Search behavior
+--smart-case
+--follow
+--hidden
+
+# Output
+--color=auto
+--colors=line:fg:yellow
+--colors=line:style:bold
+--colors=path:fg:green
+--colors=path:style:bold
+--colors=match:fg:red
+--colors=match:style:bold
+
+# Limits
+--max-columns=200
+--max-columns-preview


### PR DESCRIPTION
New tool configs:
- k9s: config.yaml with rose-pine-moon skin (full color mapping)
- bat: config with rose-pine-moon theme + custom tmTheme file
- lazydocker: rose-pine-moon colors, cpu/mem graphs
- btop: rose-pine-moon theme file, vim keys, braille graphs
- atuin: fuzzy history, compact style, session up-key filter
- navi: fzf colors matching env, custom cheatsheet path
- direnv: direnvrc with layout_python-uv, layout_go, layout_node
- posting: rose-pine theme (built-in), horizontal layout
- harlequin: rose-pine theme (built-in)
- ripgreprc: --smart-case, --hidden, --follow defaults

Modified files:
- gitconfig: expand [delta "rose-pine-moon"] with side-by-side,
  diff-stat-align-width, true-color, paging
- Makefile: add 8 new dirs to CONFIGS, add ripgreprc to FILES,
  fix rpignore typo → rgignore
- fish/config.fish: add RIPGREP_CONFIG_PATH, atuin init
  (--disable-up-arrow), navi widget init

https://claude.ai/code/session_015pEt2uyUcYWFCoB5ZxAaFH