### PR TITLE
perf(nvim): optimize startup time and per-event latency

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -1,3 +1,5 @@
+vim.loader.enable()
+
 require('config.options')
 require('core.lazy')
 require('config.autocmd')

--- a/nvim/lua/plugins/edit.lua
+++ b/nvim/lua/plugins/edit.lua
@@ -8,7 +8,7 @@ return {
   },
   {
     'stevearc/conform.nvim',
-    event = { 'BufReadPre', 'BufWritePre' },
+    event = { 'BufWritePre' },
     cmd = { 'ConformInfo' },
     ft = { 'python', 'go', 'lua', 'yaml' },
     keys = {

--- a/nvim/lua/plugins/git.lua
+++ b/nvim/lua/plugins/git.lua
@@ -28,7 +28,7 @@ return {
   },
   {
     'rhysd/committia.vim',
-    event = 'BufReadPre',
+    ft = 'gitcommit',
     config = function()
       vim.g.committia_open_only_vim_starting = 0
     end,

--- a/nvim/lua/plugins/treesitter.lua
+++ b/nvim/lua/plugins/treesitter.lua
@@ -4,7 +4,7 @@ return {
     dependencies = {
       { 'theHamsta/nvim-treesitter-pairs', ft = { 'python', 'go' } },
     },
-    lazy = false,
+    event = 'BufReadPost',
     build = {
       ':TSUpdate',
       ':TSInstall! bash',

--- a/nvim/lua/plugins/ui.lua
+++ b/nvim/lua/plugins/ui.lua
@@ -44,14 +44,14 @@ return {
       vim.api.nvim_create_autocmd({ 'WinEnter', 'BufEnter', 'FocusGained' }, {
         pattern = '*',
         callback = function()
-          vim.cmd('hi Normal guibg=' .. palette.base) -- Active window background
+          vim.api.nvim_set_hl(0, 'Normal', { bg = palette.base }) -- Active window background
         end,
       })
 
       vim.api.nvim_create_autocmd({ 'WinLeave', 'BufLeave', 'FocusLost' }, {
         pattern = '*',
         callback = function()
-          vim.cmd('hi Normal guibg=' .. palette._nc) -- Inactive window background
+          vim.api.nvim_set_hl(0, 'Normal', { bg = palette._nc }) -- Inactive window background
         end,
       })
     end,


### PR DESCRIPTION
- Enable vim.loader.enable() for Neovim's built-in Lua bytecode cache
- Lazy-load nvim-treesitter on BufReadPost instead of eager load
- Fix committia.vim to load only for gitcommit filetype (was BufReadPre)
- Replace vim.cmd hi calls with nvim_set_hl() in rose-pine window autocmds
- Remove redundant BufReadPre from conform.nvim event triggers

https://claude.ai/code/session_01ADicQssD3BLqGaYX4M9gNE