### PR TITLE
fix(tmux): enable true color and propagate COLORTERM for Atuin TUI

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -22,6 +22,8 @@ set -g default-command "/opt/homebrew/bin/fish"
 set -g allow-passthrough on
 set -ga update-environment TERM
 set -ga update-environment TERM_PROGRAM
+set -ga update-environment COLORTERM
+set -as terminal-features ',xterm-kitty:RGB'
 set -as terminal-overrides ',*:Smulx=\E[4::%p1%dm'
 set -as terminal-overrides ',*:Setulc=\E[58::2::%p1%{65536}%/%d::%p1%{256}%/%{255}%&%d::%p1%{255}%&%d%;m'
 set -g extended-keys on


### PR DESCRIPTION
Add RGB terminal feature for xterm-kitty so tmux correctly advertises
true color support, and propagate COLORTERM so Atuin detects truecolor
instead of falling back and emitting raw escape sequences.

https://claude.ai/code/session_01XqmJi98w5HG74uMHikJQ6M