### PR TITLE
feat(fish): notify on dotfiles staleness at shell start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ nvim/spell/*.spl
 fish/fish*
 !fish/fishfile
 fish/conf.d/*
+!fish/conf.d/dotfiles_staleness.fish
 fish/completions/*.gen.fish
 
 # Rust

--- a/fish/conf.d/dotfiles_staleness.fish
+++ b/fish/conf.d/dotfiles_staleness.fish
@@ -1,0 +1,43 @@
+status is-interactive; or exit
+
+function __dotfiles_staleness_check --on-event fish_prompt
+    functions -e __dotfiles_staleness_check
+
+    # Resolve dotfiles root via symlink (fast, no subprocess)
+    # ~/.config/fish -> .../dotfiles/fish, strip the trailing /fish component
+    if not set -q __dotfiles_path; or not test -d "$__dotfiles_path/.git"
+        set -l link (readlink $__fish_config_dir)
+        if test -n "$link"
+            set -U __dotfiles_path (string replace -r '/fish/?$' '' $link)
+        else if command -q ghq
+            set -U __dotfiles_path (ghq list --full-path sebastianmarkow/dotfiles 2>/dev/null)[1]
+        end
+    end
+
+    set -l repo $__dotfiles_path
+    test -d "$repo/.git" || return
+
+    # Background git fetch — throttled to once per hour
+    set -l ts_file $HOME/.cache/fish/dotfiles_fetch_ts
+    set -l now (date +%s)
+    set -l age 99999
+
+    if test -f $ts_file
+        set age (math $now - (cat $ts_file))
+    end
+
+    if test $age -gt 3600
+        mkdir -p $HOME/.cache/fish
+        echo $now >$ts_file
+        git -C $repo fetch --quiet 2>/dev/null &
+        disown
+    end
+
+    # Local staleness check — compares HEAD vs cached remote tracking branch (no network)
+    set -l behind (git -C $repo rev-list HEAD..@{upstream} --count 2>/dev/null)
+    test -n "$behind" -a "$behind" != "0" || return
+
+    set_color yellow
+    printf "dotfiles: %s commit(s) behind remote\n" $behind
+    set_color normal
+end


### PR DESCRIPTION
Adds a fish conf.d script that checks whether the dotfiles repo is
behind its remote and prints a one-line yellow warning on the first
prompt of each new shell session.

Two-layer approach keeps startup cost near zero:
- git fetch runs in the background at most once per hour (timestamp
  cached in ~/.cache/fish/dotfiles_fetch_ts), disowned so it never
  produces a job-done notification
- staleness check uses git rev-list HEAD..@{upstream} --count which
  is a pure local operation and completes in <1ms

The dotfiles repo path is resolved once by following the ~/.config/fish
symlink and stored in a universal variable so subsequent shells incur
no subprocess cost to find the repo.

https://claude.ai/code/session_011AV2xx2e1cmTpp3qXQaGkp