### PR TITLE
feat(zk): integrate zk-org/zk note-taking tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ CONFIGS=\
 	posting		\
 	tmux		\
 	wtf		\
-	yazi
+	yazi		\
+	zk
 
 .DEFAULT_GOAL: help
 .PHONY: help

--- a/fish/config.fish
+++ b/fish/config.fish
@@ -45,6 +45,7 @@ set -gx TG_TF_FORWARD_STDOUT true
 set -gx USE_GKE_GCLOUD_AUTH_PLUGIN True
 set -gx RIPGREP_CONFIG_PATH $HOME/.ripgreprc
 set -gx POETRY_VIRTUALENVS_IN_PROJECT true
+set -gx ZK_NOTEBOOK_DIR $HOME/Notes
 
 # Kitty
 if set -q KITTY_INSTALLATION_DIR
@@ -112,6 +113,9 @@ abbr --add up 'upgrade'
 abbr --add v 'nvim'
 abbr --add vim 'nvim'
 abbr --add yt 'yt-dlp'
+abbr --add zn 'zk new'
+abbr --add ze 'zk edit'
+abbr --add zl 'zk list'
 abbr --add gcm --set-cursor=% 'git commit -m "%"'
 abbr --add gfix --set-cursor=% 'git commit --fixup=%'
 abbr --add gri --set-cursor=% 'git rebase -i HEAD~%'

--- a/install/util.sh
+++ b/install/util.sh
@@ -45,6 +45,7 @@ FORMULAS=(
     w3m                 # w3m - terminal web browser
     xh                  # xh - httpie-compatible HTTP client
     yank                # yank - copy terminal output to clipboard
+    zk                  # zk - plain-text note-taking with Zettelkasten
 )
 
 CASKS=(

--- a/nvim/lua/plugins/notes.lua
+++ b/nvim/lua/plugins/notes.lua
@@ -3,15 +3,20 @@ return {
   dependencies = { 'folke/snacks.nvim' },
   event = { 'BufReadPre *.md', 'BufNewFile *.md' },
   keys = {
-    { '<leader>n',  nil,                                                            desc = 'Notes/zk' },
-    { '<leader>nn', '<cmd>ZkNew { title = vim.fn.input("Title: ") }<cr>',          desc = 'New note' },
-    { '<leader>no', '<cmd>ZkNotes { sort = { "modified" } }<cr>',                  desc = 'Open notes' },
-    { '<leader>nt', '<cmd>ZkTags<cr>',                                              desc = 'Browse tags' },
-    { '<leader>nf', '<cmd>ZkNotes { sort = { "modified" }, match = { vim.fn.input("Search: ") } }<cr>', desc = 'Find notes' },
-    { '<leader>nb', '<cmd>ZkBacklinks<cr>',                                         desc = 'Backlinks' },
-    { '<leader>nl', '<cmd>ZkLinks<cr>',                                             desc = 'Links' },
-    { '<leader>nf', ":'<,'>ZkMatch<cr>",                                            mode = 'v',         desc = 'Find matching notes' },
-    { '<leader>nn', ":'<,'>ZkNewFromTitleSelection<cr>",                            mode = 'v',         desc = 'New note from selection' },
+    { '<leader>n',  nil,                                                                                   desc = 'Notes/zk' },
+    { '<leader>nn', '<cmd>ZkNew { title = vim.fn.input("Title: ") }<cr>',                                 desc = 'New note' },
+    { '<leader>nc', '<cmd>ZkNew { group = "fleeting", title = vim.fn.input("Capture: ") }<cr>',           desc = 'Capture (fleeting)' },
+    { '<leader>nj', '<cmd>ZkNew { group = "journal" }<cr>',                                               desc = 'Journal entry' },
+    { '<leader>no', '<cmd>ZkNotes { sort = { "modified" } }<cr>',                                         desc = 'Open notes' },
+    { '<leader>nt', '<cmd>ZkTags<cr>',                                                                    desc = 'Browse tags' },
+    { '<leader>nf', '<cmd>ZkNotes { sort = { "modified" }, match = { vim.fn.input("Search: ") } }<cr>',  desc = 'Find notes' },
+    { '<leader>nb', '<cmd>ZkBacklinks<cr>',                                                               desc = 'Backlinks' },
+    { '<leader>nl', '<cmd>ZkLinks<cr>',                                                                   desc = 'Links' },
+    { '<leader>nr', '<cmd>ZkNotes { createdAfter = "last two weeks", sort = { "created" } }<cr>',         desc = 'Recent notes' },
+    { '<leader>ni', '<cmd>ZkNotes { hrefs = { "inbox" } }<cr>',                                           desc = 'Inbox (fleeting)' },
+    -- Visual: create note from selection or search for matching notes
+    { '<leader>nn', ":'<,'>ZkNewFromTitleSelection { group = 'fleeting' }<cr>",                           mode = 'v', desc = 'New note from selection' },
+    { '<leader>nf', ":'<,'>ZkMatch<cr>",                                                                  mode = 'v', desc = 'Find matching notes' },
   },
   config = function()
     require('zk').setup({
@@ -26,6 +31,24 @@ return {
           filetypes = { 'markdown' },
         },
       },
+    })
+
+    -- Buffer-local keymaps that only make sense inside a zk notebook
+    vim.api.nvim_create_autocmd('FileType', {
+      pattern = 'markdown',
+      desc = 'zk buffer-local keymaps',
+      callback = function(ev)
+        if not require('zk.util').notebook_root(vim.fn.expand('%:p')) then
+          return
+        end
+        local opts = { buffer = ev.buf, silent = true }
+        -- Follow wiki-link or jump to definition
+        vim.keymap.set('n', '<CR>', vim.lsp.buf.definition, opts)
+        -- Hover preview of linked note
+        vim.keymap.set('n', 'K', vim.lsp.buf.hover, opts)
+        -- Rename note title (updates all backlinks via LSP)
+        vim.keymap.set('n', '<leader>nr', vim.lsp.buf.rename, opts)
+      end,
     })
   end,
 }

--- a/nvim/lua/plugins/notes.lua
+++ b/nvim/lua/plugins/notes.lua
@@ -1,0 +1,31 @@
+return {
+  'zk-org/zk-nvim',
+  dependencies = { 'folke/snacks.nvim' },
+  event = { 'BufReadPre *.md', 'BufNewFile *.md' },
+  keys = {
+    { '<leader>n',  nil,                                                            desc = 'Notes/zk' },
+    { '<leader>nn', '<cmd>ZkNew { title = vim.fn.input("Title: ") }<cr>',          desc = 'New note' },
+    { '<leader>no', '<cmd>ZkNotes { sort = { "modified" } }<cr>',                  desc = 'Open notes' },
+    { '<leader>nt', '<cmd>ZkTags<cr>',                                              desc = 'Browse tags' },
+    { '<leader>nf', '<cmd>ZkNotes { sort = { "modified" }, match = { vim.fn.input("Search: ") } }<cr>', desc = 'Find notes' },
+    { '<leader>nb', '<cmd>ZkBacklinks<cr>',                                         desc = 'Backlinks' },
+    { '<leader>nl', '<cmd>ZkLinks<cr>',                                             desc = 'Links' },
+    { '<leader>nf', ":'<,'>ZkMatch<cr>",                                            mode = 'v',         desc = 'Find matching notes' },
+    { '<leader>nn', ":'<,'>ZkNewFromTitleSelection<cr>",                            mode = 'v',         desc = 'New note from selection' },
+  },
+  config = function()
+    require('zk').setup({
+      picker = 'snacks_picker',
+      lsp = {
+        config = {
+          cmd = { 'zk', 'lsp' },
+          name = 'zk',
+        },
+        auto_attach = {
+          enabled = true,
+          filetypes = { 'markdown' },
+        },
+      },
+    })
+  end,
+}

--- a/zk/config.toml
+++ b/zk/config.toml
@@ -1,0 +1,39 @@
+[notebook]
+dir = "~/Notes"
+
+[note]
+language = "en"
+default-title = "Untitled"
+filename = "{{id}}"
+extension = "md"
+id-charset = "alphanum"
+id-length = 8
+id-case = "lower"
+template = "default.md"
+
+[extra]
+author = ""
+
+[format.markdown]
+link-format = "wiki"
+hashtags = true
+
+[tool]
+editor = "nvim"
+shell = "/opt/homebrew/bin/fish"
+pager = "bat --style=plain --language=markdown"
+fzf-preview = "bat --style=plain --language=markdown --color=always {path}"
+
+[lsp]
+
+[lsp.diagnostics]
+wiki-title = "hint"
+dead-link = "error"
+
+[filter]
+recents = "--sort created- --created-after 'last two weeks'"
+
+[alias]
+ls    = "zk list --quiet $@"
+daily = "zk new --no-input --title 'Daily Notes' '$ZK_NOTEBOOK_DIR/journal'"
+week  = "zk list --sort created- --created-after 'last 7 days' --quiet $@"

--- a/zk/config.toml
+++ b/zk/config.toml
@@ -4,19 +4,24 @@ dir = "~/Notes"
 [note]
 language = "en"
 default-title = "Untitled"
-filename = "{{id}}"
+# Hybrid: stable ID prefix + human-readable slug. Allows safe renames without
+# breaking wiki-links, since zk resolves links by ID prefix.
+filename = "{{id}}-{{slug title}}"
 extension = "md"
 id-charset = "alphanum"
 id-length = 8
 id-case = "lower"
 template = "default.md"
+exclude = [".git"]
 
 [extra]
 author = ""
 
 [format.markdown]
 link-format = "wiki"
+link-drop-extension = true
 hashtags = true
+colon-tags = true
 
 [tool]
 editor = "nvim"
@@ -30,10 +35,56 @@ fzf-preview = "bat --style=plain --language=markdown --color=always {path}"
 wiki-title = "hint"
 dead-link = "error"
 
+# ── Filters ──────────────────────────────────────────────────────────────────
+
 [filter]
-recents = "--sort created- --created-after 'last two weeks'"
+recent   = "--sort created- --created-after 'last two weeks'"
+today    = "--sort modified- --modified-after 'today'"
+fleeting = "path:inbox"
+orphans  = "--no-link --exclude 'journal/**'"
+
+# ── Aliases ───────────────────────────────────────────────────────────────────
 
 [alias]
-ls    = "zk list --quiet $@"
-daily = "zk new --no-input --title 'Daily Notes' '$ZK_NOTEBOOK_DIR/journal'"
-week  = "zk list --sort created- --created-after 'last 7 days' --quiet $@"
+# Quick shortcuts
+ls     = "zk list --quiet $@"
+ed     = "zk edit --interactive $@"
+
+# Recency
+recent = "zk edit --interactive --sort created- --created-after 'last two weeks' $@"
+today  = "zk edit --interactive --sort modified- --modified-after 'today' $@"
+
+# Note weight (identify stubs)
+wc     = "zk list --format '{{word-count}}\t{{title}}' --sort word-count $@"
+
+# Backlink hygiene: find notes missing a reciprocal link
+bl     = "zk edit --interactive --missing-backlink $@"
+
+# Random note for review
+lucky  = "zk list --quiet --sort random --limit 1"
+
+# Capture quick thoughts into inbox
+cap    = "zk new --no-input --group fleeting $@"
+
+# Daily journal entry (idempotent via --no-input if already exists today)
+daily  = "zk new --no-input --group journal"
+
+# ── Groups ────────────────────────────────────────────────────────────────────
+
+[group.journal]
+paths = ["journal/**"]
+
+[group.journal.note]
+filename = "{{format-date now '%Y/%m/%Y-%m-%d'}}"
+extension = "md"
+template = "journal.md"
+default-title = "{{format-date now '%Y-%m-%d'}}"
+
+[group.fleeting]
+paths = ["inbox/**"]
+
+[group.fleeting.note]
+filename = "{{id}}-{{slug title}}"
+extension = "md"
+template = "fleeting.md"
+default-title = "Fleeting Note"

--- a/zk/templates/default.md
+++ b/zk/templates/default.md
@@ -1,0 +1,7 @@
+# {{title}}
+
+created: {{format-date now '%Y-%m-%d'}}
+tags:
+
+---
+

--- a/zk/templates/fleeting.md
+++ b/zk/templates/fleeting.md
@@ -1,0 +1,7 @@
+# {{title}}
+
+created: {{format-date now '%Y-%m-%d'}}
+tags: #inbox
+
+---
+

--- a/zk/templates/journal.md
+++ b/zk/templates/journal.md
@@ -1,0 +1,8 @@
+# {{format-date now '%Y-%m-%d'}}
+
+## Notes
+
+## Done
+
+## Tomorrow
+


### PR DESCRIPTION
- Add zk formula to install/util.sh
- Add zk/config.toml with notebook dir ~/Notes, nvim editor, fish shell,
  bat pager, fzf preview, and useful aliases (ls, daily, week)
- Register zk in Makefile CONFIGS for symlinking to ~/.config/zk
- Export ZK_NOTEBOOK_DIR and add zn/ze/zl abbreviations in fish
- Add nvim/lua/plugins/notes.lua with zk-nvim using snacks_picker,
  LSP auto-attach for markdown, and <leader>n keybindings

https://claude.ai/code/session_017d563RoKEd2gVh8bxuUFMc