### PR TITLE
fix: update configs for lazygit v0.55, yazi v25.12.29, neovim v0.11

### DIFF
--- a/lazygit/config.yml
+++ b/lazygit/config.yml
@@ -85,7 +85,6 @@ git:
   paging:
     colorArg: always
     pager: "delta --features=rose-pine-moon --paging=never"
-    useConfig: false
     externalDiffCommand: ""
   commit:
     signOff: false

--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -58,8 +58,8 @@ return {
         map('K', vim.lsp.buf.hover, 'Hover Documentation')
         map('<leader>lr', vim.lsp.buf.rename, 'Rename')
         map('<leader>la', vim.lsp.buf.code_action, 'Code Action')
-        map('[d', vim.diagnostic.goto_prev, 'Previous Diagnostic')
-        map(']d', vim.diagnostic.goto_next, 'Next Diagnostic')
+        map('[d', function() vim.diagnostic.jump({ count = -1 }) end, 'Previous Diagnostic')
+        map(']d', function() vim.diagnostic.jump({ count = 1 }) end, 'Next Diagnostic')
         map('<leader>lf', vim.diagnostic.open_float, 'Show Diagnostic Float')
       end
 

--- a/yazi/yazi.toml
+++ b/yazi/yazi.toml
@@ -14,7 +14,6 @@ show_hidden    = true
 show_symlink   = true
 scrolloff      = 5
 mouse_events   = [ "click", "scroll" ]
-title_format   = "yazi: {cwd}"
 
 [preview]
 wrap            = "no"
@@ -69,8 +68,6 @@ rules = [
 ]
 
 [tasks]
-micro_workers    = 10
-macro_workers    = 10
 bizarre_retry    = 3
 image_alloc      = 536870912  # 512MB
 image_bound      = [ 5000, 5000 ]


### PR DESCRIPTION
## What was checked

Weekly breaking-change scan across all configured tools:

| Tool | Latest version | Status |
|---|---|---|
| Neovim | v0.11.7 (2026-03-28) | **Breaking change found** |
| lazygit | v0.60.0 (2026-03-10) | **Breaking change found** |
| yazi | v26.1.22 (2026-01-22) | **Breaking change found** |
| kitty | v0.46.2 | No breaking changes in config |
| atuin | v18.13.6 | No breaking changes in config |
| starship | v1.24.2 | No breaking changes in config |
| fish | v4.6.0 | No breaking changes in config |
| tmux | v3.6a | No breaking changes in config |
| k9s | v0.50.18 | No breaking changes in config |

## What changed

### `lazygit/config.yml`

**lazygit v0.55.0:** `git.paging.useConfig` was removed upstream. The key was silently dead. Removed it.

```diff
-    useConfig: false
```

### `yazi/yazi.toml`

**yazi v25.12.29:** `title_format` was removed from `[mgr]`. The key no longer has any effect. Removed it.

```diff
-title_format   = "yazi: {cwd}"
```

**yazi v25.12.29:** `micro_workers` and `macro_workers` were removed from `[tasks]`. These keys are no longer recognised. Removed them.

```diff
-micro_workers    = 10
-macro_workers    = 10
```

### `nvim/lua/plugins/lsp.lua`

**Neovim v0.11:** `vim.diagnostic.goto_prev()` and `vim.diagnostic.goto_next()` were deprecated in favour of the unified `vim.diagnostic.jump({ count = ±1 })` API. They generate deprecation warnings in `:checkhealth` and are scheduled for removal.

```diff
-        map('[d', vim.diagnostic.goto_prev, 'Previous Diagnostic')
-        map(']d', vim.diagnostic.goto_next, 'Next Diagnostic')
+        map('[d', function() vim.diagnostic.jump({ count = -1 }) end, 'Previous Diagnostic')
+        map(']d', function() vim.diagnostic.jump({ count = 1 }) end, 'Next Diagnostic')
```

## Manual verification

- **lazygit:** Open lazygit — delta pager should still work normally. No `useConfig` warnings.
- **yazi:** Open yazi — file manager should start without errors. Terminal title will use the OS/shell default instead of `yazi: {cwd}`.
- **Neovim:** Open a file with LSP diagnostics. Confirm `[d` and `]d` still cycle through diagnostics. Run `:checkhealth vim.diagnostic` — no deprecation warnings should appear.

https://claude.ai/code/session_01XjNRfwB1QcURotMemM3EW4