### PR TITLE
Add markdown rendering support with render-markdown.nvim

### DIFF
--- a/install/python.sh
+++ b/install/python.sh
@@ -9,6 +9,12 @@ FORMULAS=(
     uv     # uv - fast Python package manager
 )
 
+MODULES=(
+    pylatexenc  # pylatexenc - LaTeX to Unicode for render-markdown.nvim
+)
+
 h1 "python"
 h2 "brew formulas"
 for f in "${FORMULAS[@]}"; do brew_install "$f"; done
+h2 "pip modules"
+for m in "${MODULES[@]}"; do pip_install "$m"; done

--- a/nvim/lua/plugins/markdown.lua
+++ b/nvim/lua/plugins/markdown.lua
@@ -57,6 +57,13 @@ return {
         style = 'full',
         cell = 'padded',
       },
+      latex = {
+        enabled = true,
+        converter = 'latex2text',
+        highlight = 'RenderMarkdownMath',
+        top_pad = 0,
+        bottom_pad = 0,
+      },
       link = {
         enabled = true,
         footnote = { superscript = true },

--- a/nvim/lua/plugins/markdown.lua
+++ b/nvim/lua/plugins/markdown.lua
@@ -1,0 +1,70 @@
+return {
+  {
+    'MeanderingProgrammer/render-markdown.nvim',
+    dependencies = {
+      'nvim-treesitter/nvim-treesitter',
+      'echasnovski/mini.icons',
+    },
+    ft = { 'markdown' },
+    opts = {
+      render_modes = { 'n', 'c', 't' },
+      anti_conceal = { enabled = true },
+      heading = {
+        enabled = true,
+        sign = false,
+        icons = { '󰉫 ', '󰉬 ', '󰉭 ', '󰉮 ', '󰉯 ', '󰉰 ' },
+        width = 'full',
+        left_pad = 0,
+        right_pad = 0,
+      },
+      code = {
+        enabled = true,
+        sign = false,
+        style = 'full',
+        border = 'thin',
+        left_pad = 1,
+        right_pad = 1,
+        width = 'full',
+        language_pad = 1,
+      },
+      dash = {
+        enabled = true,
+        icon = '─',
+        width = 'full',
+      },
+      bullet = {
+        enabled = true,
+        icons = { '●', '○', '◆', '◇' },
+        left_pad = 0,
+        right_pad = 1,
+      },
+      checkbox = {
+        enabled = true,
+        unchecked = { icon = '󰄱 ' },
+        checked = { icon = '󰱒 ' },
+        custom = {
+          todo = { raw = '[-]', rendered = '󰥔 ', highlight = 'RenderMarkdownTodo' },
+        },
+      },
+      quote = {
+        enabled = true,
+        icon = '▋',
+        repeat_linebreak = true,
+      },
+      pipe_table = {
+        enabled = true,
+        preset = 'round',
+        style = 'full',
+        cell = 'padded',
+      },
+      link = {
+        enabled = true,
+        footnote = { superscript = true },
+        image = '󰥶 ',
+        email = '󰀓 ',
+        hyperlink = '󰌹 ',
+        wiki = { icon = '󱗖 ' },
+      },
+    },
+  },
+}

--- a/nvim/lua/plugins/treesitter.lua
+++ b/nvim/lua/plugins/treesitter.lua
@@ -26,6 +26,7 @@ return {
       ':TSInstall! luadoc',
       ':TSInstall! make',
       ':TSInstall! markdown',
+      ':TSInstall! markdown_inline',
       ':TSInstall! mermaid',
       ':TSInstall! proto',
       ':TSInstall! python',

--- a/nvim/lua/plugins/treesitter.lua
+++ b/nvim/lua/plugins/treesitter.lua
@@ -27,6 +27,7 @@ return {
       ':TSInstall! make',
       ':TSInstall! markdown',
       ':TSInstall! markdown_inline',
+      ':TSInstall! latex',
       ':TSInstall! mermaid',
       ':TSInstall! proto',
       ':TSInstall! python',


### PR DESCRIPTION
## Summary
This PR adds comprehensive markdown rendering capabilities to Neovim using the `render-markdown.nvim` plugin, with full support for markdown syntax highlighting, LaTeX math rendering, and enhanced visual formatting.

## Key Changes
- **New markdown plugin configuration** (`nvim/lua/plugins/markdown.lua`):
  - Integrated `render-markdown.nvim` with `nvim-treesitter` and `mini.icons` dependencies
  - Configured rendering for normal, command, and terminal modes
  - Enabled and customized rendering for:
    - Headings with custom icons and full-width display
    - Code blocks with thin borders and language padding
    - Horizontal dashes, bullet points, and checkboxes with custom icons
    - Block quotes with line break repetition
    - Pipe tables with rounded preset styling
    - LaTeX math expressions with `latex2text` converter
    - Links with icons for images, emails, hyperlinks, and wiki links

- **Python dependencies** (`install/python.sh`):
  - Added `pylatexenc` module installation for LaTeX to Unicode conversion (required by render-markdown.nvim for math rendering)

- **Treesitter parsers** (`nvim/lua/plugins/treesitter.lua`):
  - Added `markdown_inline` parser for inline markdown syntax
  - Added `latex` parser for LaTeX math expression support

## Implementation Details
The markdown plugin is configured to render in all modes (normal, command, and terminal) with anti-conceal enabled to prevent text hiding. All major markdown elements have been customized with Unicode icons for better visual presentation while maintaining readability.

https://claude.ai/code/session_01EEoCdERndskVTHb9fm6GhJ