### PR TITLE
fix: migrate nvim lsp config for mason-lspconfig v2 breaking change

### DIFF
--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -47,39 +47,32 @@ return {
     config = function()
       require('mason').setup()
 
-      local on_attach = function(_, bufnr)
-        local map = function(keys, func, desc)
-          vim.keymap.set('n', keys, func, { buffer = bufnr, desc = desc })
-        end
-        map('gd', vim.lsp.buf.definition, 'Goto Definition')
-        map('gD', vim.lsp.buf.declaration, 'Goto Declaration')
-        map('gi', vim.lsp.buf.implementation, 'Goto Implementation')
-        map('gr', vim.lsp.buf.references, 'Goto References')
-        map('K', vim.lsp.buf.hover, 'Hover Documentation')
-        map('<leader>lr', vim.lsp.buf.rename, 'Rename')
-        map('<leader>la', vim.lsp.buf.code_action, 'Code Action')
-        map('[d', function() vim.diagnostic.jump({ count = -1 }) end, 'Previous Diagnostic')
-        map(']d', function() vim.diagnostic.jump({ count = 1 }) end, 'Next Diagnostic')
-        map('<leader>lf', vim.diagnostic.open_float, 'Show Diagnostic Float')
-      end
-
       local capabilities = vim.lsp.protocol.make_client_capabilities()
       local ok, blink = pcall(require, 'blink.cmp')
       if ok then
         capabilities = blink.get_lsp_capabilities(capabilities)
       end
+      vim.lsp.config('*', { capabilities = capabilities })
 
-      require('mason-lspconfig').setup({
-        handlers = {
-          function(server_name)
-            local server_ok, server_config = pcall(require, 'lsp.' .. server_name)
-            local config = server_ok and server_config or {}
-            config.on_attach = on_attach
-            config.capabilities = capabilities
-            require('lspconfig')[server_name].setup(config)
-          end,
-        },
+      vim.api.nvim_create_autocmd('LspAttach', {
+        callback = function(ev)
+          local map = function(keys, func, desc)
+            vim.keymap.set('n', keys, func, { buffer = ev.buf, desc = desc })
+          end
+          map('gd', vim.lsp.buf.definition, 'Goto Definition')
+          map('gD', vim.lsp.buf.declaration, 'Goto Declaration')
+          map('gi', vim.lsp.buf.implementation, 'Goto Implementation')
+          map('gr', vim.lsp.buf.references, 'Goto References')
+          map('K', vim.lsp.buf.hover, 'Hover Documentation')
+          map('<leader>lr', vim.lsp.buf.rename, 'Rename')
+          map('<leader>la', vim.lsp.buf.code_action, 'Code Action')
+          map('[d', function() vim.diagnostic.jump({ count = -1 }) end, 'Previous Diagnostic')
+          map(']d', function() vim.diagnostic.jump({ count = 1 }) end, 'Next Diagnostic')
+          map('<leader>lf', vim.diagnostic.open_float, 'Show Diagnostic Float')
+        end,
       })
+
+      require('mason-lspconfig').setup()
 
       vim.diagnostic.config({
         virtual_text = true,


### PR DESCRIPTION
## What was checked

Ran weekly breaking-change audit across all configured tools: tmux, kitty, fish, yazi, atuin, lazygit, starship, neovim and its plugins (mason, mason-lspconfig, nvim-lspconfig, blink.cmp, treesitter, gitsigns, which-key, neo-tree, snacks, conform, render-markdown).

One breaking change found requiring a config fix.

---

## Change

### mason-lspconfig v2.0.0 — `handlers` table removed (`nvim/lua/plugins/lsp.lua`)

The `handlers` config key was removed in mason-lspconfig v2.0.0. The config was migrated to the Neovim 0.11 native LSP API:

- `vim.lsp.config('*', { capabilities })` — sets capabilities globally for all servers
- `LspAttach` autocmd — replaces the `on_attach` function for per-buffer keymaps
- `mason-lspconfig.setup()` with no args — uses `automatic_enable = true` default, which calls `vim.lsp.enable()` for each installed server

The existing `nvim/lsp/basedpyright.lua` and `nvim/lsp/lua_ls.lua` files needed no changes — they already return a config table, and `vim.lsp.enable()` loads them automatically from the `lsp/` runtimepath directory.

---

## Tools with no action needed

| Tool | Status |
|---|---|
| tmux | No breaking changes (3.6a) |
| kitty | Not affected by 0.46.0 changes |
| fish | No breaking changes through 4.6.0 |
| yazi | Already correct for v25.12.29 + v26.1.22 (`id = "mime.local"`, `url` fields) |
| atuin | No breaking changes through v18.13.6 |
| lazygit | No config-breaking changes in v0.58–0.60 |
| starship | No 2026 releases yet |
| gitsigns v2 | Config uses only safe keys |
| blink.cmp | No cmdline config used |
| which-key, neo-tree, snacks, conform, render-markdown, rose-pine | No breaking changes |

---

## Manual verification before merging

- Open a Python or Lua file in neovim and confirm LSP attaches (`K` for hover, `gd` for definition, `<leader>lr` for rename)
- Run `:Mason` and confirm servers are still installed and active
- Run `:LspInfo` to verify servers attached to the current buffer

https://claude.ai/code/session_01SKNwtwj8wnfvNhu8UbjFbw