### PR TITLE
fix: update yazi opener rules for deprecated shell parameter syntax

### DIFF
--- a/yazi/yazi.toml
+++ b/yazi/yazi.toml
@@ -29,21 +29,21 @@ ueberzug_offset = [ 0, 0, 0, 0 ]
 
 [opener]
 edit = [
-	{ run = '${EDITOR:-nvim} "$@"', desc = "$EDITOR", block = true, for = "unix" },
+	{ run = '${EDITOR:-nvim} %s', desc = "$EDITOR", block = true, for = "unix" },
 ]
 open = [
-	{ run = 'open "$@"',     desc = "Open", for = "macos" },
-	{ run = 'xdg-open "$1"', desc = "Open", for = "linux" },
+	{ run = 'open %s',      desc = "Open", for = "macos" },
+	{ run = 'xdg-open %s1', desc = "Open", for = "linux" },
 ]
 reveal = [
-	{ run = 'open -R "$1"',                     desc = "Reveal",             for = "macos" },
-	{ run = 'xdg-open "$(dirname "$1")"',        desc = "Reveal in manager",  for = "linux" },
+	{ run = 'open -R %s1',  desc = "Reveal",            for = "macos" },
+	{ run = 'xdg-open %d1', desc = "Reveal in manager", for = "linux" },
 ]
 extract = [
-	{ run = 'ya pub extract --list "$@"', desc = "Extract here" },
+	{ run = 'ya pub extract --list %s', desc = "Extract here" },
 ]
 play = [
-	{ run = 'mpv --force-window "$@"', orphan = true, for = "unix" },
+	{ run = 'mpv --force-window %s', orphan = true, for = "unix" },
 ]
 
 [open]


### PR DESCRIPTION
## What was checked

Weekly maintenance scan (2026-03-30) across all configured tools:

| Tool | Latest | Status |
|------|--------|--------|
| yazi | v26.1.22 | **action required** — deprecated syntax |
| starship | v1.24.2 | no breaking changes |
| atuin | v18.13.6 | no breaking changes |
| k9s | v0.50.18 | config already correct |
| kitty | v0.46.2 | no breaking changes |

## What changed and why

**`yazi/yazi.toml` — opener rules shell parameter syntax**

yazi v25.12.29 deprecated the old shell parameter style (`$@`, `$1`, `$n`) in opener rules in favour of yazi's own shell-formatting syntax (PR [#3232](https://github.com/sxyazi/yazi/pull/3232)). The old syntax is still functional but will be removed in a future release.

Migrations applied:

| Old | New | Meaning |
|-----|-----|---------|
| `"$@"` | `%s` | all selected files (auto shell-escaped) |
| `"$1"` | `%s1` | 1st selected file |
| `"$(dirname "$1")"` | `%d1` | dirname of 1st selected file |

The new `%s`/`%s1`/`%d1` tokens are substituted by yazi before the shell sees the command, with automatic escaping — no need for manual quoting.

## Verification before merging

- Open yazi and confirm `e` (edit) opens files in `$EDITOR`
- Confirm `Enter` (open) opens files/dirs normally
- Confirm reveal action opens the containing folder
- Confirm `x` (extract) unpacks archives
- Confirm `p` (play) opens media in mpv

https://claude.ai/code/session_01CLJWF8kJ8AsrAkog9HeuyA