### PR TITLE
fix: update yazi theme.toml for v0.4.0 and v25.5.28 breaking changes

### DIFF
--- a/yazi/theme.toml
+++ b/yazi/theme.toml
@@ -22,17 +22,21 @@ marker_selected = { fg = "#9ccfd8", bg = "#9ccfd8" }
 marker_copied   = { fg = "#f6c177", bg = "#f6c177" }
 marker_cut      = { fg = "#eb6f92", bg = "#eb6f92" }
 
-# Tab — active is brighter/more prominent
-tab_active   = { fg = "#e0def4", bg = "#393552", bold = true }
-tab_inactive = { fg = "#908caa", bg = "#2a273f" }
-tab_width    = 1
-
 # Border
 border_symbol = "│"
 border_style  = { fg = "#393552" }
 
 # Syntax highlighting
 syntect_theme = "~/.config/yazi/rose-pine.tmTheme"
+
+# : }}}
+
+
+# : Tabs {{{
+
+[tabs]
+tab_active   = { fg = "#e0def4", bg = "#393552", bold = true }
+tab_inactive = { fg = "#908caa", bg = "#2a273f" }
 
 # : }}}
 
@@ -84,9 +88,9 @@ selected = { reversed = true }
 # : }}}
 
 
-# : Select {{{
+# : Pick {{{
 
-[select]
+[pick]
 border   = { fg = "#393552" }
 active   = { fg = "#c4a7e7", bold = true }
 inactive = { fg = "#908caa" }
@@ -144,15 +148,15 @@ rules = [
     { mime = "audio/*", fg = "#f6c177" },
 
     # Archives — love (red/pink)
-    { mime = "application/zip",             fg = "#eb6f92" },
-    { mime = "application/gzip",            fg = "#eb6f92" },
-    { mime = "application/x-tar",           fg = "#eb6f92" },
-    { mime = "application/x-bzip",          fg = "#eb6f92" },
-    { mime = "application/x-bzip2",         fg = "#eb6f92" },
-    { mime = "application/x-7z-compressed", fg = "#eb6f92" },
-    { mime = "application/x-rar",           fg = "#eb6f92" },
-    { mime = "application/zstd",            fg = "#eb6f92" },
-    { mime = "application/x-xz",            fg = "#eb6f92" },
+    { mime = "application/zip",           fg = "#eb6f92" },
+    { mime = "application/gzip",          fg = "#eb6f92" },
+    { mime = "application/tar",           fg = "#eb6f92" },
+    { mime = "application/bzip",          fg = "#eb6f92" },
+    { mime = "application/bzip2",         fg = "#eb6f92" },
+    { mime = "application/7z-compressed", fg = "#eb6f92" },
+    { mime = "application/rar",           fg = "#eb6f92" },
+    { mime = "application/zstd",          fg = "#eb6f92" },
+    { mime = "application/xz",            fg = "#eb6f92" },
 
     # Documents — rose (soft pink)
     { mime = "application/pdf",                          fg = "#ea9a97" },


### PR DESCRIPTION
## What was checked

Weekly maintenance pass across all configured tools: fish, tmux, neovim, starship, kitty, atuin, yazi, lazygit, lazydocker, btop, k9s, bat, delta, direnv, fzf, ripgrep, zoxide, and others.

- **lazygit v0.61.0** (2026-04-06): no config breaking changes
- **kitty v0.46.x**: no config breaking changes
- **starship**: no breaking changes (config already uses `format =` not the old `prompt_order`)
- **atuin**: no breaking changes affecting this config
- **fish 4.x**: no deprecated features used in config
- **tmux 3.5**: `set -ga update-environment` and `set -as terminal-overrides` remain valid

**yazi** had three breaking changes across v0.4.0 and v25.5.28 that were not yet applied to `theme.toml`.

## What changed

`yazi/theme.toml` — three fixes:

### 1. `[select]` → `[pick]` (yazi v0.4.0)
The theme section for the "open with" dialog was renamed from `[select]` to `[pick]` to match the renamed `pick` command. The keymap and yazi.toml had already been updated, but theme.toml was missed.

### 2. Archive MIME types: remove `x-` prefix (yazi v0.4.0)
yazi's mime plugin no longer emits `application/x-*` types. The `[filetype]` coloring rules for archives still used the old format, so they silently stopped matching:
- `application/x-tar` → `application/tar`
- `application/x-bzip` → `application/bzip`
- `application/x-bzip2` → `application/bzip2`
- `application/x-7z-compressed` → `application/7z-compressed`
- `application/x-rar` → `application/rar`
- `application/x-xz` → `application/xz`

### 3. Move tab styles to `[tabs]`, remove `tab_width` (yazi v25.5.28)
Tab styling was extracted from `[mgr]` into a dedicated `[tabs]` section. `tab_width` was removed as it is no longer user-configurable.

## Verification before merging

After merging and symlinking, open yazi and confirm:
- Archive files (`.tar.gz`, `.zip`, `.rar`, `.7z`) appear in the love/pink color
- The "open with" picker dialog retains its Rose Pine Moon theme
- Tab bar (when multiple tabs open) shows correct active/inactive colors

https://claude.ai/code/session_01D8WmPYoXWZ5Hh4kqaPpCjP