### PR TITLE
fix: update lazygit and yazi theme.toml for breaking config changes (2026-04-26)

### DIFF
--- a/lazygit/config.yml
+++ b/lazygit/config.yml
@@ -224,7 +224,7 @@ keybinding:
     nextScreenMode: +
     prevScreenMode: _
     undo: z
-    redo: <c-z>
+    redo: Z
     filteringMenu: <c-s>
     diffingMenu: W
     diffingMenu-alt: <c-e>

--- a/yazi/theme.toml
+++ b/yazi/theme.toml
@@ -35,8 +35,10 @@ syntect_theme = "~/.config/yazi/rose-pine.tmTheme"
 # : Tabs {{{
 
 [tabs]
-tab_active   = { fg = "#e0def4", bg = "#393552", bold = true }
-tab_inactive = { fg = "#908caa", bg = "#2a273f" }
+active   = { fg = "#e0def4", bg = "#393552", bold = true }
+inactive = { fg = "#908caa", bg = "#2a273f" }
+sep_inner = { open = "", close = "" }
+sep_outer = { open = "", close = "" }
 
 # : }}}
 
@@ -53,14 +55,9 @@ preview = { underline = true }
 # : Status {{{
 
 [status]
-separator_open  = ""
-separator_close = ""
-separator_style = { fg = "#2a273f", bg = "#2a273f" }
-
-# Mode — iris for normal (calm), foam for select (active), love for unset (danger)
-mode_normal = { fg = "#232136", bg = "#c4a7e7", bold = true }
-mode_select = { fg = "#232136", bg = "#9ccfd8", bold = true }
-mode_unset  = { fg = "#e0def4", bg = "#eb6f92", bold = true }
+overall   = {}
+sep_left  = { open = "", close = "" }
+sep_right = { open = "", close = "" }
 
 # Progress
 progress_label  = { fg = "#e0def4", bold = true }
@@ -68,11 +65,27 @@ progress_normal = { fg = "#9ccfd8", bg = "#2a273f" }
 progress_error  = { fg = "#eb6f92", bg = "#2a273f" }
 
 # Permissions — pine/gold/love/foam matches conventional read/write/exec colors
-permissions_t = { fg = "#3e8fb0" }
-permissions_r = { fg = "#f6c177" }
-permissions_w = { fg = "#eb6f92" }
-permissions_x = { fg = "#9ccfd8", bold = true }
-permissions_s = { fg = "#56526e" }
+perm_type  = { fg = "#3e8fb0" }
+perm_read  = { fg = "#f6c177" }
+perm_write = { fg = "#eb6f92" }
+perm_exec  = { fg = "#9ccfd8", bold = true }
+perm_sep   = { fg = "#56526e" }
+
+# : }}}
+
+
+# : Mode {{{
+
+[mode]
+# Mode — iris for normal (calm), foam for select (active), love for unset (danger)
+normal_main = { fg = "#232136", bg = "#c4a7e7", bold = true }
+normal_alt  = { fg = "#c4a7e7", bg = "#2a273f" }
+
+select_main = { fg = "#232136", bg = "#9ccfd8", bold = true }
+select_alt  = { fg = "#9ccfd8", bg = "#2a273f" }
+
+unset_main  = { fg = "#e0def4", bg = "#eb6f92", bold = true }
+unset_alt   = { fg = "#eb6f92", bg = "#2a273f" }
 
 # : }}}
 


### PR DESCRIPTION
## What was checked

Reviewed latest releases and changelogs for all configured tools: atuin, bat, btop, direnv, fish, gitconfig, hammerspoon, harlequin, k9s, kitty, lazydocker, lazygit, mackup, navi, nvim, opencode, posting, ripgrep, starship, tmux, wtf, yazi, zk.

No new breaking changes found in: atuin (v18.15.2), starship (v1.25.0), kitty (v0.46.2), neovim (v0.12.2), k9s, fish, tmux, or any other tools.

---

## Fix 1: lazygit v0.55.0 (from 2026-04-19)

In v0.55.0, `ctrl-z` was repurposed to `suspendApp` (suspend to shell, standard Unix SIGTSTP behaviour). The `redo` command was moved to `shift-Z` as the new default.

The config had an explicit `redo: <ctrl-z>` binding — the old default — which now conflicts with the new `suspendApp: <ctrl-z>` binding. Without this fix, pressing `ctrl-z` in lazygit would attempt to trigger both redo and suspend simultaneously.

```diff
-    redo: <ctrl-z>
+    redo: Z
```

`Z` (uppercase) is lazygit's config notation for `shift-Z`, matching the new upstream default.

---

## Fix 2: yazi theme.toml — multiple key renames (introduced across v25.2.26–v26.x)

Several theme.toml keys were renamed or restructured and the old names are no longer accepted (yazi validates config and rejects unknown keys).

### [tabs] section

```diff
-tab_active   = { fg = "#e0def4", bg = "#393552", bold = true }
-tab_inactive = { fg = "#908caa", bg = "#2a273f" }
+active    = { fg = "#e0def4", bg = "#393552", bold = true }
+inactive  = { fg = "#908caa", bg = "#2a273f" }
+sep_inner = { open = "", close = "" }
+sep_outer = { open = "", close = "" }
```

### [status] section — separator, mode, and permissions keys

```diff
-separator_open  = ""
-separator_close = ""
-separator_style = { fg = "#2a273f", bg = "#2a273f" }
-mode_normal = { fg = "#232136", bg = "#c4a7e7", bold = true }
-mode_select = { fg = "#232136", bg = "#9ccfd8", bold = true }
-mode_unset  = { fg = "#e0def4", bg = "#eb6f92", bold = true }
-permissions_t = { fg = "#3e8fb0" }
-permissions_r = { fg = "#f6c177" }
-permissions_w = { fg = "#eb6f92" }
-permissions_x = { fg = "#9ccfd8", bold = true }
-permissions_s = { fg = "#56526e" }
+overall   = {}
+sep_left  = { open = "", close = "" }
+sep_right = { open = "", close = "" }
+perm_type  = { fg = "#3e8fb0" }
+perm_read  = { fg = "#f6c177" }
+perm_write = { fg = "#eb6f92" }
+perm_exec  = { fg = "#9ccfd8", bold = true }
+perm_sep   = { fg = "#56526e" }
```

### New [mode] section

Mode styles moved out of `[status]` into a dedicated `[mode]` block with `_main` (badge) and `_alt` (separator transition) variants:

```toml
[mode]
normal_main = { fg = "#232136", bg = "#c4a7e7", bold = true }
normal_alt  = { fg = "#c4a7e7", bg = "#2a273f" }
select_main = { fg = "#232136", bg = "#9ccfd8", bold = true }
select_alt  = { fg = "#9ccfd8", bg = "#2a273f" }
unset_main  = { fg = "#e0def4", bg = "#eb6f92", bold = true }
unset_alt   = { fg = "#eb6f92", bg = "#2a273f" }
```

---

## Verification

After merging, open lazygit and confirm:
- `z` → undo
- `Z` (shift-Z) → redo
- `ctrl-z` → suspends lazygit to shell; `fg` resumes it

Open yazi and confirm:
- Tab bar renders correctly (active tab highlighted, inactive dimmed)
- Status bar shows mode label (iris for normal, foam for select, love for unset)
- File permissions column renders with correct colours
- No startup warnings about unknown config keys