### PR TITLE
fix: breaking config changes — yazi v26.5.6 fetcher rename + lazygit subprocess removal

### DIFF
--- a/lazygit/config.yml
+++ b/lazygit/config.yml
@@ -145,7 +145,7 @@ customCommands:
     context: commits
     description: "Autosquash fixup commits from selected base"
     command: "git rebase --interactive --autosquash {{.SelectedLocalCommit.Sha}}^"
-    subprocess: true
+    output: terminal
     loadingText: "Autosquashing..."
 
   # Delete all local branches already merged into main

--- a/yazi/yazi.toml
+++ b/yazi/yazi.toml
@@ -76,7 +76,7 @@ suppress_preload = false
 [plugin]
 fetchers = [
 	# Mimetype
-	{ id = "mime.local", url = "*", run = "mime", prio = "high" },
+	{ group = "mime.local", url = "*", run = "mime", prio = "high" },
 ]
 spotters = [
 	{ url = "*/", run = "folder" },


### PR DESCRIPTION
## What was checked (2026-06-21 re-run)

Weekly breaking-change audit across all configured tools:

| Tool | Latest | Status |
|------|--------|--------|
| yazi | v26.5.6 | **Fixed in original commit** — fetcher `id` → `group` rename |
| lazygit | v0.62.2 | **New breaking change found — fixed** — `subprocess` field removed |
| atuin | v18.16.1 | No config-breaking changes (`auto_sync = false`, unaffected by sync v1 deprecation) |
| kitty | v0.47.4 | No breaking config changes |
| starship | v1.25.0 | No breaking changes |
| tmux | latest | No breaking config changes |
| k9s | v0.51.0 | No breaking config changes |
| fish | latest | No breaking config changes |

## What changed and why

### Commit 1 — yazi v26.5.6 (original)

**`yazi/yazi.toml`** — yazi v26.5.6 renamed the fetcher rule `id` field to `group`. Hard rename; yazi ignores the old key entirely.

```toml
# Before
{ id = "mime.local", url = "*", run = "mime", prio = "high" }

# After
{ group = "mime.local", url = "*", run = "mime", prio = "high" }
```

### Commit 2 — lazygit subprocess removal (new, added 2026-06-21)

**`lazygit/config.yml`** — The `subprocess` field was removed from lazygit's custom command schema and replaced by `output`. The autosquash rebase custom command used `subprocess: true` (equivalent to `output: terminal`). Without the fix, lazygit auto-migrates the field on first launch but the dotfiles repo stays stale; on read-only mounts the migration silently fails, leaving the interactive rebase running in the wrong context.

```yaml
# Before
command: "git rebase --interactive --autosquash {{.SelectedLocalCommit.Sha}}^"
subprocess: true

# After
command: "git rebase --interactive --autosquash {{.SelectedLocalCommit.Sha}}^"
output: terminal
```

## Manual verification

- **yazi**: run `yazi`, confirm startup without errors, file type detection works (text file, image, directory).
- **lazygit**: open lazygit in a repo with fixup commits, select a base commit in the Commits panel, press `<alt-s>` — should suspend lazygit and open the interactive rebase editor in the terminal, then return to lazygit on exit.